### PR TITLE
Fix: Audit January 2026

### DIFF
--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -275,9 +275,12 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         (address actualTokenA, uint256 actualAmountADesired) = _handleTokenIn(tokenA, amountADesired);
         (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenIn(tokenB, amountBDesired);
 
+        // Cache token ordering comparison (JUICE1-11 fix)
+        bool isAToken0 = actualTokenA < actualTokenB;
+
         // Ensure token0 < token1 (Uniswap V3 requirement)
         (address token0, address token1, uint256 amount0Desired, uint256 amount1Desired) =
-            actualTokenA < actualTokenB
+            isAToken0
                 ? (actualTokenA, actualTokenB, actualAmountADesired, actualAmountBDesired)
                 : (actualTokenB, actualTokenA, actualAmountBDesired, actualAmountADesired);
 
@@ -286,7 +289,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         uint256 actualAmountBMin = tokenB == address(JUSD) ? _jusdToSvJusdAmount(amountBMin) : amountBMin;
 
         (uint256 amount0Min, uint256 amount1Min) =
-            actualTokenA < actualTokenB
+            isAToken0
                 ? (actualAmountAMin, actualAmountBMin)
                 : (actualAmountBMin, actualAmountAMin);
 
@@ -309,14 +312,14 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         (uint256 tokenId, , uint256 amount0, uint256 amount1) = POSITION_MANAGER.mint(params);
 
         // Map back to A/B order
-        (amountA, amountB) = actualTokenA < actualTokenB ? (amount0, amount1) : (amount1, amount0);
+        (amountA, amountB) = isAToken0 ? (amount0, amount1) : (amount1, amount0);
         liquidity = tokenId; // Return NFT tokenId as "liquidity"
 
         // Return excess tokens to user
-        uint256 excessA = actualTokenA < actualTokenB
+        uint256 excessA = isAToken0
             ? (amount0Desired > amount0 ? amount0Desired - amount0 : 0)
             : (amount1Desired > amount1 ? amount1Desired - amount1 : 0);
-        uint256 excessB = actualTokenA < actualTokenB
+        uint256 excessB = isAToken0
             ? (amount1Desired > amount1 ? amount1Desired - amount1 : 0)
             : (amount0Desired > amount0 ? amount0Desired - amount0 : 0);
 

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -28,7 +28,6 @@ interface ISwapRouter {
         address tokenOut;
         uint24 fee;
         address recipient;
-        uint256 deadline;
         uint256 amountIn;
         uint256 amountOutMinimum;
         uint160 sqrtPriceLimitX96;
@@ -39,7 +38,6 @@ interface ISwapRouter {
     struct ExactInputParams {
         bytes path;
         address recipient;
-        uint256 deadline;
         uint256 amountIn;
         uint256 amountOutMinimum;
     }
@@ -234,7 +232,6 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             tokenOut: actualTokenOut,
             fee: effectiveFee,
             recipient: address(this),
-            deadline: deadline,
             amountIn: actualAmountIn,
             amountOutMinimum: 0, // Slippage checked after conversions
             sqrtPriceLimitX96: 0

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -554,6 +554,10 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      */
     function setDefaultFee(uint24 newFee) external onlyOwner {
         if (newFee >= 1_000_000) revert InvalidFee(newFee);
+        // Verify fee tier is enabled in factory (JUICE1-7 fix)
+        int24 tickSpacing = FACTORY.feeAmountTickSpacing(newFee);
+        if (tickSpacing == 0) revert InvalidFee(newFee);
+
         uint24 oldFee = defaultFee;
         defaultFee = newFee;
         emit DefaultFeeUpdated(oldFee, newFee);

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -391,6 +391,10 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         amountA = _handleTokenOut(tokenA, actualAmountA, to);
         amountB = _handleTokenOut(tokenB, actualAmountB, to);
 
+        // Verify final amounts meet user's minimums after all conversions (JUICE1-4 fix)
+        if (amountA < amountAMin) revert InsufficientOutput();
+        if (amountB < amountBMin) revert InsufficientOutput();
+
         // Return NFT to user
         IERC721(address(POSITION_MANAGER)).safeTransferFrom(address(this), msg.sender, tokenId);
 

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -217,7 +217,10 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     ) external payable nonReentrant whenNotPaused returns (uint256 amountOut) {
         if (block.timestamp > deadline) revert DeadlineExpired();
         if (amountIn == 0) revert InvalidAmount();
-        if (fee >= 1_000_000) revert InvalidFee(fee);
+
+        // Use defaultFee when fee is 0 (JUICE1-6 fix)
+        uint24 effectiveFee = fee == 0 ? defaultFee : fee;
+        if (effectiveFee >= 1_000_000) revert InvalidFee(effectiveFee);
 
         // Step 1: Handle input token conversion
         (address actualTokenIn, uint256 actualAmountIn) = _handleTokenIn(tokenIn, amountIn);
@@ -229,7 +232,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
             tokenIn: actualTokenIn,
             tokenOut: actualTokenOut,
-            fee: fee,
+            fee: effectiveFee,
             recipient: address(this),
             deadline: deadline,
             amountIn: actualAmountIn,
@@ -265,6 +268,9 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     ) external payable nonReentrant whenNotPaused returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
         if (block.timestamp > deadline) revert DeadlineExpired();
 
+        // Use defaultFee when fee is 0 (JUICE1-6 fix)
+        uint24 effectiveFee = fee == 0 ? defaultFee : fee;
+
         // Convert input tokens
         (address actualTokenA, uint256 actualAmountADesired) = _handleTokenIn(tokenA, amountADesired);
         (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenIn(tokenB, amountBDesired);
@@ -284,12 +290,12 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
                 ? (actualAmountAMin, actualAmountBMin)
                 : (actualAmountBMin, actualAmountAMin);
 
-        (int24 tickLower, int24 tickUpper) = _getFullRangeTicks(fee);
+        (int24 tickLower, int24 tickUpper) = _getFullRangeTicks(effectiveFee);
 
         INonfungiblePositionManager.MintParams memory params = INonfungiblePositionManager.MintParams({
             token0: token0,
             token1: token1,
-            fee: fee,
+            fee: effectiveFee,
             tickLower: tickLower,
             tickUpper: tickUpper,
             amount0Desired: amount0Desired,

--- a/contracts/governance/JuiceSwapFeeCollector.sol
+++ b/contracts/governance/JuiceSwapFeeCollector.sol
@@ -128,10 +128,15 @@ contract JuiceSwapFeeCollector is Ownable, ReentrancyGuard {
 
         uint256 jusdBefore = JUSD.balanceOf(address(this));
 
+        // Only collect tokens that have valid swap paths or are already JUSD (JUICE1-13 fix)
+        // This prevents tokens from getting stuck in the contract when no path is provided
+        bool shouldCollect0 = token0 == address(JUSD) || path0.length > 0;
+        bool shouldCollect1 = token1 == address(JUSD) || path1.length > 0;
+
         (uint128 amount0, uint128 amount1) = v3Pool.collectProtocol(
             address(this),
-            type(uint128).max,
-            type(uint128).max
+            shouldCollect0 ? type(uint128).max : 0,
+            shouldCollect1 ? type(uint128).max : 0
         );
 
         // Swap token0 to JUSD if needed (path0.length > 0 means swap is required)

--- a/contracts/governance/JuiceSwapFeeCollector.sol
+++ b/contracts/governance/JuiceSwapFeeCollector.sol
@@ -19,7 +19,6 @@ interface ISwapRouter {
     struct ExactInputParams {
         bytes path;
         address recipient;
-        uint256 deadline;
         uint256 amountIn;
         uint256 amountOutMinimum;
     }
@@ -198,7 +197,6 @@ contract JuiceSwapFeeCollector is Ownable, ReentrancyGuard {
             ISwapRouter.ExactInputParams({
                 path: path,
                 recipient: address(this),
-                deadline: block.timestamp + 5 minutes,
                 amountIn: amountIn,
                 amountOutMinimum: minOutput
             })

--- a/contracts/governance/JuiceSwapFeeCollector.sol
+++ b/contracts/governance/JuiceSwapFeeCollector.sol
@@ -57,6 +57,7 @@ contract JuiceSwapFeeCollector is Ownable, ReentrancyGuard {
     address public swapRouter; // Uniswap V3 SwapRouter address
     uint32 public twapPeriod; // TWAP observation period in seconds
     uint256 public maxSlippageBps; // Maximum allowed slippage in basis points (e.g., 200 = 2%)
+    uint32 public expectedBlockTime; // Expected block time in seconds (e.g., 2 for Citrea)
 
     address public authorizedCollector; // Address authorized to collect fees
 
@@ -71,12 +72,14 @@ contract JuiceSwapFeeCollector is Ownable, ReentrancyGuard {
     event CollectorUpdated(address indexed oldCollector, address indexed newCollector);
     event FactoryOwnerUpdated(address indexed newOwner);
     event FeeAmountEnabled(uint24 indexed fee, int24 indexed tickSpacing);
+    event ExpectedBlockTimeUpdated(uint32 blockTime);
 
     error InvalidAddress();
     error InvalidParams();
     error PoolDoesNotExist();
     error Unauthorized();
     error InvalidPath();
+    error InsufficientCardinality(address pool);
 
     constructor(
         address _jusd,
@@ -96,9 +99,10 @@ contract JuiceSwapFeeCollector is Ownable, ReentrancyGuard {
         swapRouter = _swapRouter;
         FACTORY = _factory;
 
-        // Initialize protection parameters (30 minutes TWAP, 2% max slippage)
+        // Initialize protection parameters (30 minutes TWAP, 2% max slippage, 2s blocks for Citrea)
         twapPeriod = 1800;
         maxSlippageBps = 200;
+        expectedBlockTime = 2; // Citrea has 2-second block time
     }
 
     /**
@@ -245,6 +249,12 @@ contract JuiceSwapFeeCollector is Ownable, ReentrancyGuard {
             // Get pool address
             address pool = _computePoolAddress(FACTORY, tokenIn, tokenOut, fee);
 
+            // Verify pool has sufficient observation cardinality for TWAP (JUICE1-14 fix)
+            // Cardinality must cover the full TWAP window: twapPeriod / blockTime + 1
+            (,, , uint16 observationCardinality,,,) = IUniswapV3Pool(pool).slot0();
+            uint256 minCardinality = (uint256(twapPeriod) / uint256(expectedBlockTime)) + 1;
+            if (observationCardinality < minCardinality) revert InsufficientCardinality(pool);
+
             // Get TWAP tick for this pool
             (int24 twapTick, ) = OracleLibrary.consult(pool, twapPeriod);
 
@@ -296,6 +306,21 @@ contract JuiceSwapFeeCollector is Ownable, ReentrancyGuard {
         maxSlippageBps = _maxSlippageBps;
 
         emit ProtectionParamsUpdated(_twapPeriod, _maxSlippageBps);
+    }
+
+    /**
+     * @notice Update expected block time for cardinality calculations
+     * @param _blockTime Expected block time in seconds
+     * @dev Only callable by owner (governance). Used to calculate minimum
+     *      observation cardinality for TWAP protection.
+     */
+    function setExpectedBlockTime(uint32 _blockTime) external onlyOwner {
+        if (_blockTime == 0) revert InvalidParams();
+        if (_blockTime > 60) revert InvalidParams(); // Sanity check: max 60 seconds
+
+        expectedBlockTime = _blockTime;
+
+        emit ExpectedBlockTimeUpdated(_blockTime);
     }
 
     /**

--- a/contracts/mocks/MockERC4626.sol
+++ b/contracts/mocks/MockERC4626.sol
@@ -54,4 +54,12 @@ contract MockERC4626 is ERC4626 {
     function accrueInterest(uint256 interestAmount) external {
         _totalAssets += interestAmount;
     }
+
+    /**
+     * @notice Mint shares for testing (allows MockSwapRouter to mint output tokens)
+     */
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+        _totalAssets += amount; // Keep totalAssets in sync
+    }
 }

--- a/contracts/mocks/MockEquity.sol
+++ b/contracts/mocks/MockEquity.sol
@@ -15,6 +15,10 @@ contract MockEquity is ERC20 {
     // Simple pricing: 1 JUICE = 100 JUSD (can be adjusted)
     uint256 public constant PRICE = 100e18;
 
+    // Override for testing slippage scenarios (JUICE1-4)
+    uint256 private _investReturnOverride;
+    bool private _useInvestOverride;
+
     constructor(
         string memory name,
         string memory symbol,
@@ -34,11 +38,32 @@ contract MockEquity is ERC20 {
 
         JUSD.transferFrom(msg.sender, address(this), amount);
 
-        // Calculate shares: amount / PRICE
-        shares = (amount * 1e18) / PRICE;
+        // Use override if set (for testing slippage scenarios)
+        if (_useInvestOverride) {
+            shares = _investReturnOverride;
+        } else {
+            // Calculate shares: amount / PRICE
+            shares = (amount * 1e18) / PRICE;
+        }
         _mint(msg.sender, shares);
 
         return shares;
+    }
+
+    /**
+     * @notice Set a custom invest return amount for testing
+     * @param amount The fixed amount of JUICE to return from invest()
+     */
+    function setInvestReturn(uint256 amount) external {
+        _investReturnOverride = amount;
+        _useInvestOverride = true;
+    }
+
+    /**
+     * @notice Clear the invest override and return to normal behavior
+     */
+    function clearInvestOverride() external {
+        _useInvestOverride = false;
     }
 
     /**

--- a/contracts/mocks/MockSwapRouter.sol
+++ b/contracts/mocks/MockSwapRouter.sol
@@ -9,8 +9,13 @@ interface IMintableERC20 {
 
 /**
  * @title MockSwapRouter
- * @notice Mock implementation of Uniswap V3 SwapRouter for testing
- * @dev Simulates swap behavior without actual pool logic
+ * @notice Mock implementation of Uniswap V3 SwapRouter02 for testing
+ * @dev Simulates swap behavior without actual pool logic.
+ *      Accurately simulates real SwapRouter02 behavior where tokens are
+ *      pulled via transferFrom from the caller (Gateway) during the pool callback.
+ *
+ *      SwapRouter02's exactInputSingle does NOT have a deadline parameter -
+ *      that was only in the original SwapRouter.
  */
 contract MockSwapRouter {
     uint256 private _outputAmount;
@@ -20,7 +25,6 @@ contract MockSwapRouter {
         address tokenOut;
         uint24 fee;
         address recipient;
-        uint256 deadline;
         uint256 amountIn;
         uint256 amountOutMinimum;
         uint160 sqrtPriceLimitX96;
@@ -35,13 +39,16 @@ contract MockSwapRouter {
 
     /**
      * @notice Mock exactInputSingle swap
+     * @dev Simulates real SwapRouter02 behavior:
+     *      The router pulls tokens from msg.sender via transferFrom during the
+     *      pool callback. The caller must have approved the router for the input amount.
      */
     function exactInputSingle(ExactInputSingleParams calldata params)
         external
         payable
         returns (uint256 amountOut)
     {
-        // Transfer input token from sender
+        // Pull input tokens from caller (simulates pool callback behavior)
         IERC20(params.tokenIn).transferFrom(msg.sender, address(this), params.amountIn);
 
         // Calculate output amount

--- a/contracts/mocks/MockWETH.sol
+++ b/contracts/mocks/MockWETH.sol
@@ -30,4 +30,11 @@ contract MockWETH is ERC20 {
         _mint(msg.sender, msg.value);
         emit Deposit(msg.sender, msg.value);
     }
+
+    /**
+     * @notice Mint tokens for testing (allows MockSwapRouter to mint output tokens)
+     */
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
 }

--- a/test/JuiceSwapFeeCollector.test.ts
+++ b/test/JuiceSwapFeeCollector.test.ts
@@ -133,9 +133,10 @@ async function createAndInitializePool(
   // Initialize pool with price
   await pool.initialize(sqrtPriceX96);
 
-  // Increase observation cardinality for TWAP
+  // Increase observation cardinality for TWAP (JUICE1-14: needs twapPeriod/blockTime + 1)
+  // For testing with 1800s TWAP and 2s blocks, we need 901 cardinality
   // NOTE: Actual cardinality won't increase until next observation is written
-  await pool.increaseObservationCardinalityNext(100);
+  await pool.increaseObservationCardinalityNext(1000);
 
   return pool;
 }
@@ -724,6 +725,49 @@ describe.skip("JuiceSwapFeeCollector - Real Uniswap V3 Integration", function ()
       await expect(
         feeCollector.connect(owner).setProtectionParams(1800, 1500) // 15% (too high)
       ).to.be.revertedWithCustomError(feeCollector, "InvalidParams");
+    });
+
+    it("Should allow owner to update expected block time", async function () {
+      const { feeCollector, owner } = await loadFixture(deployFeeCollectorFixture);
+
+      const newBlockTime = 12; // Ethereum mainnet
+
+      await expect(
+        feeCollector.connect(owner).setExpectedBlockTime(newBlockTime)
+      ).to.emit(feeCollector, "ExpectedBlockTimeUpdated")
+        .withArgs(newBlockTime);
+
+      expect(await feeCollector.expectedBlockTime()).to.equal(newBlockTime);
+    });
+
+    it("Should revert if expected block time is zero", async function () {
+      const { feeCollector, owner } = await loadFixture(deployFeeCollectorFixture);
+
+      await expect(
+        feeCollector.connect(owner).setExpectedBlockTime(0)
+      ).to.be.revertedWithCustomError(feeCollector, "InvalidParams");
+    });
+
+    it("Should revert if expected block time exceeds 60 seconds", async function () {
+      const { feeCollector, owner } = await loadFixture(deployFeeCollectorFixture);
+
+      await expect(
+        feeCollector.connect(owner).setExpectedBlockTime(61)
+      ).to.be.revertedWithCustomError(feeCollector, "InvalidParams");
+    });
+
+    it("Should revert if non-owner tries to set expected block time", async function () {
+      const { feeCollector, unauthorized } = await loadFixture(deployFeeCollectorFixture);
+
+      await expect(
+        feeCollector.connect(unauthorized).setExpectedBlockTime(12)
+      ).to.be.revertedWithCustomError(feeCollector, "OwnableUnauthorizedAccount");
+    });
+
+    it("Should initialize expectedBlockTime to 2 (Citrea default)", async function () {
+      const { feeCollector } = await loadFixture(deployFeeCollectorFixture);
+
+      expect(await feeCollector.expectedBlockTime()).to.equal(2);
     });
   });
 

--- a/test/JuiceSwapGateway.integration.ts
+++ b/test/JuiceSwapGateway.integration.ts
@@ -1,0 +1,217 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Signer, Contract } from "ethers";
+
+/**
+ * JuiceSwapGateway Integration Tests - Citrea Testnet
+ *
+ * Run: yarn hardhat test test/JuiceSwapGateway.integration.ts --network citreaTestnet
+ *
+ * Prerequisites:
+ * - DEPLOYER_PRIVATE_KEY env var with funded account (JUSD, WcBTC, native cBTC)
+ */
+
+const ADDRESSES = {
+  JuiceSwapGateway: "0x44B89B1a71f72aB6FeFa807686511f3589163704",
+  JUSD: "0xFdB0a83d94CD65151148a131167Eb499Cb85d015",
+  svJUSD: "0x9580498224551E3f2e3A04330a684BF025111C53",
+  WcBTC: "0x8d0c9d1c17aE5e40ffF9bE350f57840E9E66Cd93",
+  JUICE: "0x7b2A560bf72B0Dd2EAbE3271F829C2597c8420d5",
+};
+
+const ERC20_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function approve(address, uint256) returns (bool)",
+  "function allowance(address, address) view returns (uint256)",
+];
+
+const GATEWAY_ABI = [
+  "function swapExactTokensForTokens(address tokenIn, address tokenOut, uint24 fee, uint256 amountIn, uint256 minAmountOut, address to, uint256 deadline) payable returns (uint256)",
+  "event SwapExecuted(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut)",
+];
+
+// Skip entire test suite if not on Citrea Testnet
+const isIntegrationTest = process.env.HARDHAT_NETWORK === "citreaTestnet";
+
+(isIntegrationTest ? describe : describe.skip)("JuiceSwapGateway Integration Tests (Citrea Testnet)", function () {
+  this.timeout(120_000);
+
+  let signer: Signer;
+  let signerAddress: string;
+  let gateway: Contract;
+  let jusd: Contract;
+  let wcbtc: Contract;
+  let juice: Contract;
+
+  const JUSD_AMOUNT = 1_000_000n; // 1 JUSD (6 decimals)
+  const WCBTC_AMOUNT = 1000n; // 0.00001 WcBTC (8 decimals)
+  const CBTC_AMOUNT = 1000n; // 0.00001 cBTC (8 decimals)
+  const FEE = 3000; // 0.3%
+
+  const getDeadline = () => Math.floor(Date.now() / 1000) + 3600;
+
+  async function ensureApproval(token: Contract, amount: bigint) {
+    const allowance = await token.allowance(signerAddress, ADDRESSES.JuiceSwapGateway);
+    if (allowance < amount) {
+      const tx = await token.approve(ADDRESSES.JuiceSwapGateway, ethers.MaxUint256);
+      await tx.wait();
+    }
+  }
+
+  function findSwapEvent(receipt: any): boolean {
+    return receipt.logs.some((log: any) => {
+      try {
+        return gateway.interface.parseLog(log)?.name === "SwapExecuted";
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  before(async function () {
+    const signers = await ethers.getSigners();
+    if (signers.length === 0) {
+      console.log("Skipping: No signer. Set DEPLOYER_PRIVATE_KEY env var.");
+      return this.skip();
+    }
+
+    signer = signers[0];
+    signerAddress = await signer.getAddress();
+    console.log(`\n  Test account: ${signerAddress}`);
+
+    gateway = new ethers.Contract(ADDRESSES.JuiceSwapGateway, GATEWAY_ABI, signer);
+    jusd = new ethers.Contract(ADDRESSES.JUSD, ERC20_ABI, signer);
+    wcbtc = new ethers.Contract(ADDRESSES.WcBTC, ERC20_ABI, signer);
+    juice = new ethers.Contract(ADDRESSES.JUICE, ERC20_ABI, signer);
+
+    const [jusdBal, wcbtcBal, cbtcBal] = await Promise.all([
+      jusd.balanceOf(signerAddress),
+      wcbtc.balanceOf(signerAddress),
+      ethers.provider.getBalance(signerAddress),
+    ]);
+
+    console.log(`  JUSD: ${ethers.formatUnits(jusdBal, 6)}`);
+    console.log(`  WcBTC: ${ethers.formatUnits(wcbtcBal, 8)}`);
+    console.log(`  cBTC: ${ethers.formatUnits(cbtcBal, 8)}\n`);
+  });
+
+  describe("1. JUSD -> WcBTC", function () {
+    it("Should swap JUSD for WcBTC (JUSD->svJUSD conversion + pool swap)", async function () {
+      const balance = await jusd.balanceOf(signerAddress);
+      if (balance < JUSD_AMOUNT) this.skip();
+
+      await ensureApproval(jusd, JUSD_AMOUNT);
+      const wcbtcBefore = await wcbtc.balanceOf(signerAddress);
+
+      console.log(`    Swapping ${ethers.formatUnits(JUSD_AMOUNT, 6)} JUSD -> WcBTC...`);
+      const tx = await gateway.swapExactTokensForTokens(
+        ADDRESSES.JUSD,
+        ADDRESSES.WcBTC,
+        FEE,
+        JUSD_AMOUNT,
+        0,
+        signerAddress,
+        getDeadline()
+      );
+      const receipt = await tx.wait();
+
+      const wcbtcAfter = await wcbtc.balanceOf(signerAddress);
+      const received = wcbtcAfter - wcbtcBefore;
+      console.log(`    Received: ${ethers.formatUnits(received, 8)} WcBTC`);
+
+      expect(receipt.status).to.equal(1);
+      expect(received).to.be.gt(0);
+      expect(findSwapEvent(receipt)).to.be.true;
+    });
+  });
+
+  describe("2. WcBTC -> JUSD", function () {
+    it("Should swap WcBTC for JUSD (pool swap + svJUSD->JUSD conversion)", async function () {
+      const balance = await wcbtc.balanceOf(signerAddress);
+      if (balance < WCBTC_AMOUNT) this.skip();
+
+      await ensureApproval(wcbtc, WCBTC_AMOUNT);
+      const jusdBefore = await jusd.balanceOf(signerAddress);
+
+      console.log(`    Swapping ${ethers.formatUnits(WCBTC_AMOUNT, 8)} WcBTC -> JUSD...`);
+      const tx = await gateway.swapExactTokensForTokens(
+        ADDRESSES.WcBTC,
+        ADDRESSES.JUSD,
+        FEE,
+        WCBTC_AMOUNT,
+        0,
+        signerAddress,
+        getDeadline()
+      );
+      const receipt = await tx.wait();
+
+      const jusdAfter = await jusd.balanceOf(signerAddress);
+      const received = jusdAfter - jusdBefore;
+      console.log(`    Received: ${ethers.formatUnits(received, 6)} JUSD`);
+
+      expect(receipt.status).to.equal(1);
+      expect(received).to.be.gt(0);
+      expect(findSwapEvent(receipt)).to.be.true;
+    });
+  });
+
+  describe("3. Native cBTC -> JUSD", function () {
+    it("Should swap native cBTC for JUSD (cBTC->WcBTC wrap + pool swap + svJUSD->JUSD)", async function () {
+      const balance = await ethers.provider.getBalance(signerAddress);
+      if (balance < CBTC_AMOUNT + ethers.parseEther("0.0005")) this.skip();
+
+      const jusdBefore = await jusd.balanceOf(signerAddress);
+
+      console.log(`    Swapping ${ethers.formatUnits(CBTC_AMOUNT, 8)} cBTC -> JUSD...`);
+      const tx = await gateway.swapExactTokensForTokens(
+        ethers.ZeroAddress,
+        ADDRESSES.JUSD,
+        FEE,
+        CBTC_AMOUNT,
+        0,
+        signerAddress,
+        getDeadline(),
+        { value: CBTC_AMOUNT }
+      );
+      const receipt = await tx.wait();
+
+      const jusdAfter = await jusd.balanceOf(signerAddress);
+      const received = jusdAfter - jusdBefore;
+      console.log(`    Received: ${ethers.formatUnits(received, 6)} JUSD`);
+
+      expect(receipt.status).to.equal(1);
+      expect(received).to.be.gt(0);
+      expect(findSwapEvent(receipt)).to.be.true;
+    });
+  });
+
+  describe("4. WcBTC -> JUICE", function () {
+    it("Should swap WcBTC for JUICE (pool swap + svJUSD->JUSD + Equity.invest)", async function () {
+      const balance = await wcbtc.balanceOf(signerAddress);
+      if (balance < WCBTC_AMOUNT) this.skip();
+
+      await ensureApproval(wcbtc, WCBTC_AMOUNT);
+      const juiceBefore = await juice.balanceOf(signerAddress);
+
+      console.log(`    Swapping ${ethers.formatUnits(WCBTC_AMOUNT, 8)} WcBTC -> JUICE...`);
+      const tx = await gateway.swapExactTokensForTokens(
+        ADDRESSES.WcBTC,
+        ADDRESSES.JUICE,
+        FEE,
+        WCBTC_AMOUNT,
+        0,
+        signerAddress,
+        getDeadline()
+      );
+      const receipt = await tx.wait();
+
+      const juiceAfter = await juice.balanceOf(signerAddress);
+      const received = juiceAfter - juiceBefore;
+      console.log(`    Received: ${ethers.formatUnits(received, 18)} JUICE`);
+
+      expect(receipt.status).to.equal(1);
+      expect(received).to.be.gt(0);
+      expect(findSwapEvent(receipt)).to.be.true;
+    });
+  });
+});

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -1,8 +1,15 @@
 import { expect } from "chai";
 import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
 import { ethers } from "hardhat";
-import { JuiceSwapGateway } from "../typechain-types";
-import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import {
+  JuiceSwapGateway,
+  MockERC20,
+  MockEquity,
+  MockERC4626,
+  MockWETH,
+  MockSwapRouter,
+  MockPositionManager,
+} from "../typechain-types";
 import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
 describe("JuiceSwapGateway", function () {
@@ -19,37 +26,37 @@ describe("JuiceSwapGateway", function () {
     const [owner, user1, user2, feeCollector] = await ethers.getSigners();
 
     // Deploy Mock JUSD (ERC20)
-    const MockERC20 = await ethers.getContractFactory("MockERC20");
-    const jusd = await MockERC20.deploy("JuiceDollar", "JUSD", 18);
+    const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+    const jusd = (await MockERC20Factory.deploy("JuiceDollar", "JUSD", 18)) as unknown as MockERC20;
     await jusd.waitForDeployment();
 
     // Deploy Mock JUICE (ERC20 with Equity functions)
-    const MockEquity = await ethers.getContractFactory("MockEquity");
-    const juice = await MockEquity.deploy("Juice Protocol", "JUICE", await jusd.getAddress());
+    const MockEquityFactory = await ethers.getContractFactory("MockEquity");
+    const juice = (await MockEquityFactory.deploy("Juice Protocol", "JUICE", await jusd.getAddress())) as unknown as MockEquity;
     await juice.waitForDeployment();
 
     // Deploy Mock svJUSD (ERC4626)
-    const MockERC4626 = await ethers.getContractFactory("MockERC4626");
-    const svJusd = await MockERC4626.deploy(
+    const MockERC4626Factory = await ethers.getContractFactory("MockERC4626");
+    const svJusd = (await MockERC4626Factory.deploy(
       await jusd.getAddress(),
       "Savings Vault JUSD",
       "svJUSD"
-    );
+    )) as unknown as MockERC4626;
     await svJusd.waitForDeployment();
 
     // Deploy Mock WcBTC (WETH-like wrapper)
-    const MockWETH = await ethers.getContractFactory("MockWETH");
-    const wcbtc = await MockWETH.deploy("Wrapped cBTC", "WcBTC");
+    const MockWETHFactory = await ethers.getContractFactory("MockWETH");
+    const wcbtc = (await MockWETHFactory.deploy("Wrapped cBTC", "WcBTC")) as unknown as MockWETH;
     await wcbtc.waitForDeployment();
 
     // Deploy Mock Uniswap V3 SwapRouter
-    const MockSwapRouter = await ethers.getContractFactory("MockSwapRouter");
-    const swapRouter = await MockSwapRouter.deploy();
+    const MockSwapRouterFactory = await ethers.getContractFactory("MockSwapRouter");
+    const swapRouter = (await MockSwapRouterFactory.deploy()) as unknown as MockSwapRouter;
     await swapRouter.waitForDeployment();
 
     // Deploy Mock NonfungiblePositionManager
-    const MockPositionManager = await ethers.getContractFactory("MockPositionManager");
-    const positionManager = await MockPositionManager.deploy();
+    const MockPositionManagerFactory = await ethers.getContractFactory("MockPositionManager");
+    const positionManager = (await MockPositionManagerFactory.deploy()) as unknown as MockPositionManager;
     await positionManager.waitForDeployment();
 
     return {
@@ -73,15 +80,15 @@ describe("JuiceSwapGateway", function () {
     const mocks = await deployMocksFixture();
     const { owner, jusd, svJusd, juice, wcbtc, swapRouter, positionManager } = mocks;
 
-    const JuiceSwapGateway = await ethers.getContractFactory("JuiceSwapGateway");
-    const gateway = await JuiceSwapGateway.deploy(
+    const JuiceSwapGatewayFactory = await ethers.getContractFactory("JuiceSwapGateway");
+    const gateway = (await JuiceSwapGatewayFactory.deploy(
       await jusd.getAddress(),
       await svJusd.getAddress(),
       await juice.getAddress(),
       await wcbtc.getAddress(),
       await swapRouter.getAddress(),
       await positionManager.getAddress()
-    );
+    )) as unknown as JuiceSwapGateway;
     await gateway.waitForDeployment();
 
     return { ...mocks, gateway };
@@ -105,24 +112,15 @@ describe("JuiceSwapGateway", function () {
     await wcbtc.connect(user1).deposit({ value: ethers.parseEther("5000") });
     await wcbtc.connect(user2).deposit({ value: ethers.parseEther("5000") });
 
-    // Fund MockSwapRouter with tokens for swaps
-    // This simulates liquidity pools having tokens
-    const swapRouterAddr = await swapRouter.getAddress();
-
-    // WCBTC is a wrapper, so we need to deposit native tokens first
-    await wcbtc.deposit({ value: ethers.parseEther("1000") });
-    await wcbtc.transfer(swapRouterAddr, ethers.parseEther("1000"));
+    // NOTE: We intentionally do NOT pre-fund the MockSwapRouter with input tokens.
+    // The mocks (MockWETH, MockERC4626) now have mint() functions, allowing the router
+    // to mint output tokens on demand. This ensures tests properly verify that the
+    // Gateway transfers input tokens to the router before calling exactInputSingle.
+    // If the Gateway doesn't transfer tokens, the router's balance check will fail.
 
     // Fund svJUSD vault with JUSD so it can handle deposits and redemptions
     const svJusdAddr = await svJusd.getAddress();
-    await jusd.mint(svJusdAddr, ethers.parseEther("100000")); // Increased for redemptions
-
-    // Deposit some JUSD into svJUSD to create shares for swap router
-    // First get the signer who will do the deposit
-    const [owner] = await ethers.getSigners();
-    await jusd.mint(owner.address, ethers.parseEther("1000"));
-    await jusd.connect(owner).approve(svJusdAddr, ethers.parseEther("1000"));
-    await svJusd.connect(owner).deposit(ethers.parseEther("1000"), swapRouterAddr);
+    await jusd.mint(svJusdAddr, ethers.parseEther("100000")); // For redemptions
 
     // Fund MockEquity (JUICE contract) with JUSD for redemptions
     const juiceAddr = await juice.getAddress();
@@ -456,6 +454,162 @@ describe("JuiceSwapGateway", function () {
 
       const balanceAfter = await ethers.provider.getBalance(user1.address);
       expect(balanceAfter).to.be.gt(balanceBefore); // User received cBTC
+    });
+  });
+
+  describe("Swap: WcBTC → JUSD/JUICE", function () {
+    it("Should swap WcBTC for JUSD successfully", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } =
+        await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1");
+
+      // Mock router returns svJUSD shares which get converted to JUSD
+      // WcBTC → svJUSD (pool swap) → JUSD (unwrap)
+      await swapRouter.setSwapOutput(ethers.parseEther("100")); // 100 svJUSD shares
+
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      const jusdBalanceBefore = await jusd.balanceOf(user1.address);
+
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        await wcbtc.getAddress(),
+        await jusd.getAddress(),
+        3000,
+        swapAmount,
+        MIN_OUTPUT,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx)
+        .to.emit(gateway, "SwapExecuted")
+        .withArgs(
+          user1.address,
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          anyValue,
+          anyValue
+        );
+
+      const jusdBalanceAfter = await jusd.balanceOf(user1.address);
+      expect(jusdBalanceAfter).to.be.gt(jusdBalanceBefore);
+    });
+
+    it("Should swap WcBTC for JUICE successfully", async function () {
+      const { gateway, user1, juice, wcbtc, svJusd, swapRouter } =
+        await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1");
+
+      // Mock router returns svJUSD shares which get converted to JUSD then JUICE
+      // WcBTC → svJUSD (pool swap) → JUSD (unwrap) → JUICE (invest)
+      await swapRouter.setSwapOutput(ethers.parseEther("100")); // 100 svJUSD shares
+
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      const juiceBalanceBefore = await juice.balanceOf(user1.address);
+
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        await wcbtc.getAddress(),
+        await juice.getAddress(),
+        3000,
+        swapAmount,
+        MIN_OUTPUT,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx)
+        .to.emit(gateway, "SwapExecuted")
+        .withArgs(
+          user1.address,
+          await wcbtc.getAddress(),
+          await juice.getAddress(),
+          anyValue,
+          anyValue
+        );
+
+      const juiceBalanceAfter = await juice.balanceOf(user1.address);
+      expect(juiceBalanceAfter).to.be.gt(juiceBalanceBefore);
+    });
+
+    it("Should swap native cBTC for JUSD successfully", async function () {
+      const { gateway, user1, jusd, swapRouter } =
+        await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1");
+
+      // Mock router returns svJUSD shares which get converted to JUSD
+      // cBTC → WcBTC (wrap) → svJUSD (pool swap) → JUSD (unwrap)
+      await swapRouter.setSwapOutput(ethers.parseEther("100")); // 100 svJUSD shares
+
+      const jusdBalanceBefore = await jusd.balanceOf(user1.address);
+
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        ethers.ZeroAddress, // Native cBTC
+        await jusd.getAddress(),
+        3000,
+        swapAmount,
+        MIN_OUTPUT,
+        user1.address,
+        deadline,
+        { value: swapAmount }
+      );
+
+      await expect(tx)
+        .to.emit(gateway, "SwapExecuted")
+        .withArgs(
+          user1.address,
+          ethers.ZeroAddress,
+          await jusd.getAddress(),
+          anyValue,
+          anyValue
+        );
+
+      const jusdBalanceAfter = await jusd.balanceOf(user1.address);
+      expect(jusdBalanceAfter).to.be.gt(jusdBalanceBefore);
+    });
+
+    it("Should swap native cBTC for JUICE successfully", async function () {
+      const { gateway, user1, juice, swapRouter } =
+        await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1");
+
+      // Mock router returns svJUSD shares which get converted to JUSD then JUICE
+      // cBTC → WcBTC (wrap) → svJUSD (pool swap) → JUSD (unwrap) → JUICE (invest)
+      await swapRouter.setSwapOutput(ethers.parseEther("100")); // 100 svJUSD shares
+
+      const juiceBalanceBefore = await juice.balanceOf(user1.address);
+
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        ethers.ZeroAddress, // Native cBTC
+        await juice.getAddress(),
+        3000,
+        swapAmount,
+        MIN_OUTPUT,
+        user1.address,
+        deadline,
+        { value: swapAmount }
+      );
+
+      await expect(tx)
+        .to.emit(gateway, "SwapExecuted")
+        .withArgs(
+          user1.address,
+          ethers.ZeroAddress,
+          await juice.getAddress(),
+          anyValue,
+          anyValue
+        );
+
+      const juiceBalanceAfter = await juice.balanceOf(user1.address);
+      expect(juiceBalanceAfter).to.be.gt(juiceBalanceBefore);
     });
   });
 
@@ -987,11 +1141,18 @@ describe("JuiceSwapGateway", function () {
       await expect(gateway.connect(owner).setDefaultFee(10000)).to.not.be.reverted;
     });
 
-    it("Should accept custom fee tiers below 1M", async function () {
+    it("Should reject fee tiers not enabled in factory", async function () {
       const { gateway, owner } = await loadFixture(deployGatewayFixture);
 
-      await expect(gateway.connect(owner).setDefaultFee(2000)).to.not.be.reverted;
-      await expect(gateway.connect(owner).setDefaultFee(999999)).to.not.be.reverted;
+      // Fee tier 2000 is not a standard Uniswap V3 fee tier (100, 500, 3000, 10000)
+      await expect(
+        gateway.connect(owner).setDefaultFee(2000)
+      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
+
+      // Fee tier 999999 is also not enabled in factory
+      await expect(
+        gateway.connect(owner).setDefaultFee(999999)
+      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
     });
 
     it("Should reject fee tiers >= 1,000,000", async function () {

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -824,6 +824,72 @@ describe("JuiceSwapGateway", function () {
         )
       ).to.be.revertedWithCustomError(gateway, "DeadlineExpired");
     });
+
+    it("Should revert when JUICE output is less than minimum after conversion (JUICE1-4)", async function () {
+      const { gateway, user1, juice, svJusd, wcbtc, positionManager, jusd } =
+        await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const tokenId = 1;
+      const liquidity = 100;
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Determine token ordering (Uniswap V3 requirement: token0 < token1)
+      const svJusdIsToken0 = svJusdAddr.toLowerCase() < wcbtcAddr.toLowerCase();
+
+      // Setup position with svJUSD (which will be converted to JUICE on output)
+      await positionManager.setPositionData(
+        tokenId,
+        svJusdIsToken0 ? svJusdAddr : wcbtcAddr,
+        svJusdIsToken0 ? wcbtcAddr : svJusdAddr,
+        liquidity
+      );
+
+      // Set decrease result with correct token order
+      // amount0 corresponds to token0, amount1 to token1
+      const svJusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+      await positionManager.setDecreaseResult(
+        svJusdIsToken0 ? svJusdAmount : wcbtcAmount,
+        svJusdIsToken0 ? wcbtcAmount : svJusdAmount
+      );
+
+      // Fund position manager with tokens it will return
+      const posManagerAddr = await positionManager.getAddress();
+      const [owner] = await ethers.getSigners();
+      await jusd.mint(owner.address, svJusdAmount);
+      await jusd.connect(owner).approve(svJusdAddr, svJusdAmount);
+      await svJusd.connect(owner).deposit(svJusdAmount, posManagerAddr);
+      await wcbtc.deposit({ value: wcbtcAmount });
+      await wcbtc.transfer(posManagerAddr, wcbtcAmount);
+
+      // Set MockEquity to return less JUICE than the minimum requested
+      // User will request amountAMin of 10 JUICE, but we'll only return 5
+      await juice.setInvestReturn(ethers.parseEther("5"));
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(await gateway.getAddress(), tokenId);
+
+      // Request JUICE as output with minimum of 10 JUICE
+      // The conversion svJUSD -> JUSD -> JUICE will only return 5 JUICE (via override)
+      // This should fail the slippage check
+      await expect(
+        gateway.connect(user1).removeLiquidity(
+          await juice.getAddress(), // Request JUICE as tokenA
+          await wcbtc.getAddress(),
+          tokenId,
+          ethers.parseEther("10"), // amountAMin = 10 JUICE
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+
+      // Clean up: reset the invest override for other tests
+      await juice.clearInvestOverride();
+    });
   });
 
   describe("NFT Handling", function () {


### PR DESCRIPTION
- **fix: add slippage check after token conversion in removeLiquidity (JUICE1-4)**
- **fix: use defaultFee when fee parameter is 0 (JUICE1-6)**
- **fix: validate fee tier in setDefaultFee (JUICE1-7)**
- **fix: cache token ordering comparison in addLiquidity (JUICE1-11)**
- **fix: only collect tokens with valid swap paths (JUICE1-13)**
- **fix: check observation cardinality for TWAP protection (JUICE1-14)**
- **fix: remove deadline from ISwapRouter interface to match V3SwapRouter**
