### PR TITLE
feat(gateway): add bridged stablecoin (USDT) support

### DIFF
--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -919,6 +919,11 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             revert BridgedTokenAlreadyExists(token);
         }
 
+        // Validate bridge configuration matches expected tokens
+        IStablecoinBridge bridgeContract = IStablecoinBridge(bridge);
+        if (bridgeContract.usd() != token) revert InvalidBridgeConfig();
+        if (bridgeContract.JUSD() != address(JUSD)) revert InvalidBridgeConfig();
+
         uint8 decimals = IERC20Metadata(token).decimals();
         bridgeConfigs[token] = BridgeConfig({
             bridge: IStablecoinBridge(bridge),

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -223,6 +223,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         IERC20(_wcbtc).approve(_positionManager, type(uint256).max);
         // Approve bridged USD to StablecoinBridge for mint operations
         IERC20(_bridgedUsd).approve(_stablecoinBridge, type(uint256).max);
+        // Approve JUSD to StablecoinBridge for burn operations (burnAndSend)
+        JUSD.approve(_stablecoinBridge, type(uint256).max);
     }
 
     /**

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -598,7 +598,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             return (address(SV_JUSD), shares);
         } else {
             // Other tokens - direct transfer
-            IERC20(token).transferFrom(msg.sender, address(this), amount);
+            SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), amount);
             if (IERC20(token).allowance(address(this), address(SWAP_ROUTER)) < amount) {
                 SafeERC20.forceApprove(IERC20(token), address(SWAP_ROUTER), type(uint256).max);
             }

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -989,7 +989,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      */
     function rescueToken(address token, address to, uint256 amount) external onlyOwner {
         if (to == address(0)) revert InvalidToken();
-        IERC20(token).transfer(to, amount);
+        SafeERC20.safeTransfer(IERC20(token), to, amount);
         emit TokenRescued(token, to, amount);
     }
 

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.20;
 
 import {IJuiceSwapGateway} from "./interfaces/IJuiceSwapGateway.sol";
+import {IStablecoinBridge} from "./interfaces/IStablecoinBridge.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
@@ -149,6 +151,15 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     INonfungiblePositionManager public immutable POSITION_MANAGER;
     IUniswapV3Factory public immutable FACTORY;
 
+    /// @notice The bridged stablecoin (e.g., USDT) that can be converted to JUSD
+    IERC20 public immutable BRIDGED_USD;
+    /// @notice The StablecoinBridge contract for BRIDGED_USD ↔ JUSD conversions
+    IStablecoinBridge public immutable STABLECOIN_BRIDGE;
+    /// @notice Decimals of the bridged stablecoin (cached for gas efficiency)
+    uint8 public immutable BRIDGED_USD_DECIMALS;
+    /// @notice Decimals of JUSD (cached for gas efficiency)
+    uint8 public immutable JUSD_DECIMALS;
+
     address private constant NATIVE_TOKEN = address(0);
     uint24 public defaultFee = 3000; // 0.3% default fee tier
 
@@ -164,6 +175,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     error InvalidFee(uint24 fee);
     error TokenMismatch(address expected0, address expected1, address provided0, address provided1);
     error InsufficientLiquidity(uint128 requested, uint128 available);
+    error InvalidTokenPair(address tokenA, address tokenB);
 
     event TokenRescued(address indexed token, address indexed to, uint256 amount);
     event NativeRescued(address indexed to, uint256 amount);
@@ -177,6 +189,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      * @param _wcbtc The address of the Wrapped cBTC contract
      * @param _swapRouter The address of the Uniswap V3 SwapRouter contract
      * @param _positionManager The address of the NonfungiblePositionManager contract
+     * @param _bridgedUsd The address of the bridged stablecoin (e.g., USDT)
+     * @param _stablecoinBridge The address of the StablecoinBridge contract
      */
     constructor(
         address _jusd,
@@ -184,7 +198,9 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         address _juice,
         address _wcbtc,
         address _swapRouter,
-        address _positionManager
+        address _positionManager,
+        address _bridgedUsd,
+        address _stablecoinBridge
     ) Ownable(msg.sender) {
         JUSD = IERC20(_jusd);
         SV_JUSD = IERC4626(_svJusd);
@@ -193,6 +209,10 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         SWAP_ROUTER = ISwapRouter(_swapRouter);
         POSITION_MANAGER = INonfungiblePositionManager(_positionManager);
         FACTORY = IUniswapV3Factory(INonfungiblePositionManager(_positionManager).factory());
+        BRIDGED_USD = IERC20(_bridgedUsd);
+        STABLECOIN_BRIDGE = IStablecoinBridge(_stablecoinBridge);
+        BRIDGED_USD_DECIMALS = IERC20Metadata(_bridgedUsd).decimals();
+        JUSD_DECIMALS = IERC20Metadata(_jusd).decimals();
 
         // Pre-approve tokens for efficiency
         JUSD.approve(address(SV_JUSD), type(uint256).max);
@@ -201,6 +221,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         IERC20(_svJusd).approve(_positionManager, type(uint256).max);
         IERC20(_wcbtc).approve(_swapRouter, type(uint256).max);
         IERC20(_wcbtc).approve(_positionManager, type(uint256).max);
+        // Approve bridged USD to StablecoinBridge for mint operations
+        IERC20(_bridgedUsd).approve(_stablecoinBridge, type(uint256).max);
     }
 
     /**
@@ -268,6 +290,12 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     ) external payable nonReentrant whenNotPaused returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
         if (block.timestamp > deadline) revert DeadlineExpired();
 
+        // Prevent invalid token pairs where both tokens convert to the same actual token
+        // e.g., USDT + JUSD would both become svJUSD
+        if (_getActualToken(tokenA) == _getActualToken(tokenB)) {
+            revert InvalidTokenPair(tokenA, tokenB);
+        }
+
         // Use defaultFee when fee is 0 (JUICE1-6 fix)
         uint24 effectiveFee = fee == 0 ? defaultFee : fee;
 
@@ -285,8 +313,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
                 : (actualTokenB, actualTokenA, actualAmountBDesired, actualAmountADesired);
 
         // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = tokenA == address(JUSD) ? _jusdToSvJusdAmount(amountAMin) : amountAMin;
-        uint256 actualAmountBMin = tokenB == address(JUSD) ? _jusdToSvJusdAmount(amountBMin) : amountBMin;
+        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
 
         (uint256 amount0Min, uint256 amount1Min) =
             isAToken0
@@ -364,13 +392,13 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Transfer NFT to this contract (only after validation passes)
         IERC721(address(POSITION_MANAGER)).transferFrom(msg.sender, address(this), tokenId);
 
-        // Convert input tokens (JUSD → svJUSD)
+        // Convert input tokens (JUSD/bridged USD → svJUSD)
         (address actualTokenA, uint256 actualAmountADesired) = _handleTokenIn(tokenA, amountADesired);
         (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenIn(tokenB, amountBDesired);
 
         // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = tokenA == address(JUSD) ? _jusdToSvJusdAmount(amountAMin) : amountAMin;
-        uint256 actualAmountBMin = tokenB == address(JUSD) ? _jusdToSvJusdAmount(amountBMin) : amountBMin;
+        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
 
         // Cache token ordering comparison
         bool isAToken0 = actualTokenA < actualTokenB;
@@ -408,9 +436,9 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         _returnExcess(tokenB, actualTokenB, excessB, msg.sender);
 
         // Convert amounts back to user-facing token units for return values and event
-        // (amountA/amountB are currently in svJUSD terms if user passed JUSD)
-        uint256 userAmountA = tokenA == address(JUSD) ? _svJusdToJusdAmount(amountA) : amountA;
-        uint256 userAmountB = tokenB == address(JUSD) ? _svJusdToJusdAmount(amountB) : amountB;
+        // (amountA/amountB are currently in svJUSD terms if user passed JUSD or bridged USD)
+        uint256 userAmountA = _toUserAmount(tokenA, amountA);
+        uint256 userAmountB = _toUserAmount(tokenB, amountB);
 
         // Return NFT to user
         IERC721(address(POSITION_MANAGER)).safeTransferFrom(address(this), msg.sender, tokenId);
@@ -458,8 +486,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         address actualTokenB = _getActualToken(tokenB);
 
         // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = tokenA == address(JUSD) ? _jusdToSvJusdAmount(amountAMin) : amountAMin;
-        uint256 actualAmountBMin = tokenB == address(JUSD) ? _jusdToSvJusdAmount(amountBMin) : amountBMin;
+        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
 
         // Determine token order
         bool isAToken0 = actualTokenA < actualTokenB;
@@ -526,6 +554,16 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         return JUICE.calculateShares(jusdAmount);
     }
 
+    function bridgedUsdToSvJusd(uint256 usdAmount) external view returns (uint256) {
+        uint256 jusdAmount = _bridgedUsdToJusdAmount(usdAmount);
+        return SV_JUSD.convertToShares(jusdAmount);
+    }
+
+    function svJusdToBridgedUsd(uint256 svJusdAmount) external view returns (uint256) {
+        uint256 jusdAmount = SV_JUSD.convertToAssets(svJusdAmount);
+        return _jusdToBridgedUsdAmount(jusdAmount);
+    }
+
     // ==================== Internal Functions ====================
 
     /**
@@ -546,6 +584,16 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             // JUICE cannot be used as input due to Equity flash loan protection.
             // Users must redeem JUICE directly: JUICE.redeem() → then swap the JUSD.
             revert JuiceInputNotSupported();
+        } else if (token == address(BRIDGED_USD)) {
+            // Bridged USD (e.g., USDT) → JUSD (via Bridge) → svJUSD
+            SafeERC20.safeTransferFrom(BRIDGED_USD, msg.sender, address(this), amount);
+            // Bridge mints JUSD (handles decimal conversion internally)
+            STABLECOIN_BRIDGE.mint(amount);
+            // Convert bridged USD amount to JUSD amount (e.g., 6 decimals → 18 decimals)
+            uint256 jusdAmount = _bridgedUsdToJusdAmount(amount);
+            // Deposit JUSD into savings vault
+            uint256 shares = SV_JUSD.deposit(jusdAmount, address(this));
+            return (address(SV_JUSD), shares);
         } else {
             // Other tokens - direct transfer
             IERC20(token).transferFrom(msg.sender, address(this), amount);
@@ -577,11 +625,18 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             // svJUSD → JUSD → JUICE
             uint256 jusdAmount = SV_JUSD.redeem(actualAmount, address(this), address(this));
             uint256 juiceAmount = JUICE.invest(jusdAmount, 0);
-            JUICE.transfer(to, juiceAmount);
+            SafeERC20.safeTransfer(IERC20(address(JUICE)), to, juiceAmount);
             return juiceAmount;
+        } else if (token == address(BRIDGED_USD)) {
+            // svJUSD → JUSD → Bridged USD (e.g., USDT)
+            uint256 jusdAmount = SV_JUSD.redeem(actualAmount, address(this), address(this));
+            // Burn JUSD via bridge to get bridged USD sent to recipient
+            STABLECOIN_BRIDGE.burnAndSend(to, jusdAmount);
+            // Return amount in bridged USD decimals
+            return _jusdToBridgedUsdAmount(jusdAmount);
         } else {
             // Other tokens - direct transfer
-            IERC20(token).transfer(to, actualAmount);
+            SafeERC20.safeTransfer(IERC20(token), to, actualAmount);
             return actualAmount;
         }
     }
@@ -593,6 +648,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         if (token == NATIVE_TOKEN) return address(WCBTC);
         if (token == address(JUSD)) return address(SV_JUSD);
         if (token == address(JUICE)) return address(SV_JUSD); // JUICE swaps through equity
+        if (token == address(BRIDGED_USD)) return address(SV_JUSD); // Bridged USD converts to svJUSD
         return token;
     }
 
@@ -608,6 +664,63 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      */
     function _svJusdToJusdAmount(uint256 svJusdAmount) internal view returns (uint256) {
         return SV_JUSD.convertToAssets(svJusdAmount);
+    }
+
+    /**
+     * @dev Converts bridged USD amount to JUSD amount (e.g., 6 decimals → 18 decimals)
+     */
+    function _bridgedUsdToJusdAmount(uint256 bridgedUsdAmount) internal view returns (uint256) {
+        if (BRIDGED_USD_DECIMALS < JUSD_DECIMALS) {
+            return bridgedUsdAmount * 10 ** (JUSD_DECIMALS - BRIDGED_USD_DECIMALS);
+        } else if (BRIDGED_USD_DECIMALS > JUSD_DECIMALS) {
+            return bridgedUsdAmount / 10 ** (BRIDGED_USD_DECIMALS - JUSD_DECIMALS);
+        }
+        return bridgedUsdAmount;
+    }
+
+    /**
+     * @dev Converts JUSD amount to bridged USD amount (e.g., 18 decimals → 6 decimals)
+     */
+    function _jusdToBridgedUsdAmount(uint256 jusdAmount) internal view returns (uint256) {
+        if (JUSD_DECIMALS > BRIDGED_USD_DECIMALS) {
+            return jusdAmount / 10 ** (JUSD_DECIMALS - BRIDGED_USD_DECIMALS);
+        } else if (JUSD_DECIMALS < BRIDGED_USD_DECIMALS) {
+            return jusdAmount * 10 ** (BRIDGED_USD_DECIMALS - JUSD_DECIMALS);
+        }
+        return jusdAmount;
+    }
+
+    /**
+     * @dev Converts bridged USD amount to svJUSD shares
+     */
+    function _bridgedUsdToSvJusdAmount(uint256 bridgedUsdAmount) internal view returns (uint256) {
+        uint256 jusdAmount = _bridgedUsdToJusdAmount(bridgedUsdAmount);
+        return SV_JUSD.convertToShares(jusdAmount);
+    }
+
+    /**
+     * @dev Converts user-facing min amount to actual token min amount
+     */
+    function _toActualMinAmount(address userToken, uint256 minAmount) internal view returns (uint256) {
+        if (userToken == address(JUSD)) {
+            return _jusdToSvJusdAmount(minAmount);
+        } else if (userToken == address(BRIDGED_USD)) {
+            return _bridgedUsdToSvJusdAmount(minAmount);
+        }
+        return minAmount;
+    }
+
+    /**
+     * @dev Converts actual token amount back to user-facing token amount
+     */
+    function _toUserAmount(address userToken, uint256 actualAmount) internal view returns (uint256) {
+        if (userToken == address(JUSD)) {
+            return _svJusdToJusdAmount(actualAmount);
+        } else if (userToken == address(BRIDGED_USD)) {
+            uint256 jusdAmount = _svJusdToJusdAmount(actualAmount);
+            return _jusdToBridgedUsdAmount(jusdAmount);
+        }
+        return actualAmount;
     }
 
     /**
@@ -635,6 +748,10 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         if (userToken == address(JUSD) && actualToken == address(SV_JUSD)) {
             // Convert excess svJUSD back to JUSD
             SV_JUSD.redeem(excessAmount, to, address(this));
+        } else if (userToken == address(BRIDGED_USD) && actualToken == address(SV_JUSD)) {
+            // Convert excess svJUSD back to bridged USD via JUSD
+            uint256 jusdAmount = SV_JUSD.redeem(excessAmount, address(this), address(this));
+            STABLECOIN_BRIDGE.burnAndSend(to, jusdAmount);
         } else if (userToken == NATIVE_TOKEN && actualToken == address(WCBTC)) {
             // Convert excess WcBTC back to native cBTC
             WCBTC.withdraw(excessAmount);
@@ -642,7 +759,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             if (!success) revert TransferFailed();
         } else if (actualToken != address(0)) {
             // Return excess tokens directly
-            IERC20(actualToken).transfer(to, excessAmount);
+            SafeERC20.safeTransfer(IERC20(actualToken), to, excessAmount);
         }
     }
 

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -688,11 +688,19 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
 
     /**
      * @dev Converts bridged token amount to JUSD amount (e.g., 6 decimals → 18 decimals)
+     * @notice For tokens with fewer decimals than JUSD (e.g., USDC/USDT with 6 decimals),
+     *         this is a lossless multiplication. For tokens with more decimals than JUSD
+     *         (rare edge case), this rounds DOWN which favors the protocol on deposits.
+     * @param bridgedAmount The amount in bridged token decimals
+     * @param bridgedDecimals The decimal count of the bridged token
+     * @return The equivalent amount in JUSD decimals (18)
      */
     function _bridgedToJusdAmount(uint256 bridgedAmount, uint8 bridgedDecimals) internal view returns (uint256) {
         if (bridgedDecimals < JUSD_DECIMALS) {
+            // Scale up: lossless (e.g., 1_000000 USDC → 1_000000000000000000 JUSD)
             return bridgedAmount * 10 ** (JUSD_DECIMALS - bridgedDecimals);
         } else if (bridgedDecimals > JUSD_DECIMALS) {
+            // Scale down: intentional floor division (rare case, favors protocol)
             return bridgedAmount / 10 ** (bridgedDecimals - JUSD_DECIMALS);
         }
         return bridgedAmount;
@@ -700,11 +708,20 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
 
     /**
      * @dev Converts JUSD amount to bridged token amount (e.g., 18 decimals → 6 decimals)
+     * @notice Rounds DOWN (floor) intentionally to favor the protocol on withdrawals.
+     *         This is standard DeFi practice: users receive slightly less on outbound transfers.
+     *         Maximum precision loss per conversion: 10^(JUSD_DECIMALS - bridgedDecimals) - 1 wei
+     *         Example for 6-decimal tokens: max loss is 999999999999 wei ≈ 0.000000999999 JUSD
+     * @param jusdAmount The amount in JUSD decimals (18)
+     * @param bridgedDecimals The decimal count of the bridged token
+     * @return The equivalent amount in bridged token decimals (rounded down)
      */
     function _jusdToBridgedAmount(uint256 jusdAmount, uint8 bridgedDecimals) internal view returns (uint256) {
         if (JUSD_DECIMALS > bridgedDecimals) {
+            // Scale down: intentional floor division (favors protocol on withdrawals)
             return jusdAmount / 10 ** (JUSD_DECIMALS - bridgedDecimals);
         } else if (JUSD_DECIMALS < bridgedDecimals) {
+            // Scale up: lossless (rare case)
             return jusdAmount * 10 ** (bridgedDecimals - JUSD_DECIMALS);
         }
         return jusdAmount;
@@ -712,6 +729,12 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
 
     /**
      * @dev Converts bridged token amount to svJUSD shares
+     * @notice Two-step conversion: bridged → JUSD (lossless for 6-decimal tokens) → svJUSD shares.
+     *         The svJUSD conversion uses ERC4626 convertToShares which may introduce
+     *         additional rounding based on the vault's share price.
+     * @param bridgedAmount The amount in bridged token decimals
+     * @param bridgedDecimals The decimal count of the bridged token
+     * @return The equivalent amount in svJUSD shares
      */
     function _bridgedToSvJusdAmount(uint256 bridgedAmount, uint8 bridgedDecimals) internal view returns (uint256) {
         uint256 jusdAmount = _bridgedToJusdAmount(bridgedAmount, bridgedDecimals);

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -161,6 +161,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     mapping(address => BridgeConfig) public bridgeConfigs;
     /// @notice List of all supported bridged tokens (for enumeration)
     address[] public bridgedTokens;
+    /// @notice Maximum number of bridged tokens that can be added
+    uint8 public constant MAX_BRIDGED_TOKENS = 10;
     /// @notice Decimals of JUSD (cached for gas efficiency)
     uint8 public immutable JUSD_DECIMALS;
 
@@ -183,6 +185,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     error BridgedTokenAlreadyExists(address token);
     error BridgedTokenNotFound(address token);
     error InvalidBridgeConfig();
+    error TooManyBridgedTokens();
 
     event TokenRescued(address indexed token, address indexed to, uint256 amount);
     event NativeRescued(address indexed to, uint256 amount);
@@ -784,8 +787,10 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
                 uint256 jusdAmount = SV_JUSD.redeem(excessAmount, address(this), address(this));
                 config.bridge.burnAndSend(to, jusdAmount);
             } else {
-                // Return excess svJUSD directly (shouldn't happen in normal flow)
-                SafeERC20.safeTransfer(IERC20(actualToken), to, excessAmount);
+                // Unreachable: if actualToken is svJUSD, userToken must be JUSD (handled above)
+                // or a bridged token (handled in if-branch). JUICE maps to svJUSD but cannot
+                // be used as input (JuiceInputNotSupported), so this branch is never reached.
+                revert InvalidToken();
             }
         } else if (actualToken != address(0)) {
             // Return excess tokens directly
@@ -817,6 +822,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      */
     function addBridgedToken(address token, address bridge) external onlyOwner {
         if (token == address(0) || bridge == address(0)) revert InvalidBridgeConfig();
+        if (bridgedTokens.length >= MAX_BRIDGED_TOKENS) revert TooManyBridgedTokens();
         if (bridgeConfigs[token].bridge != IStablecoinBridge(address(0))) {
             revert BridgedTokenAlreadyExists(token);
         }

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -960,7 +960,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
 
         // Revoke approvals
         IERC20(token).approve(bridge, 0);
-        // Note: We don't revoke JUSD approval as other bridges may still need it
+        JUSD.approve(bridge, 0);
 
         emit BridgedTokenRemoved(token);
     }

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -151,12 +151,16 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     INonfungiblePositionManager public immutable POSITION_MANAGER;
     IUniswapV3Factory public immutable FACTORY;
 
-    /// @notice The bridged stablecoin (e.g., USDT) that can be converted to JUSD
-    IERC20 public immutable BRIDGED_USD;
-    /// @notice The StablecoinBridge contract for BRIDGED_USD ↔ JUSD conversions
-    IStablecoinBridge public immutable STABLECOIN_BRIDGE;
-    /// @notice Decimals of the bridged stablecoin (cached for gas efficiency)
-    uint8 public immutable BRIDGED_USD_DECIMALS;
+    /// @notice Configuration for a bridged stablecoin
+    struct BridgeConfig {
+        IStablecoinBridge bridge;
+        uint8 decimals;
+    }
+
+    /// @notice Mapping of bridged stablecoin address to its bridge configuration
+    mapping(address => BridgeConfig) public bridgeConfigs;
+    /// @notice List of all supported bridged tokens (for enumeration)
+    address[] public bridgedTokens;
     /// @notice Decimals of JUSD (cached for gas efficiency)
     uint8 public immutable JUSD_DECIMALS;
 
@@ -176,10 +180,15 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     error TokenMismatch(address expected0, address expected1, address provided0, address provided1);
     error InsufficientLiquidity(uint128 requested, uint128 available);
     error InvalidTokenPair(address tokenA, address tokenB);
+    error BridgedTokenAlreadyExists(address token);
+    error BridgedTokenNotFound(address token);
+    error InvalidBridgeConfig();
 
     event TokenRescued(address indexed token, address indexed to, uint256 amount);
     event NativeRescued(address indexed to, uint256 amount);
     event DefaultFeeUpdated(uint24 oldFee, uint24 newFee);
+    event BridgedTokenAdded(address indexed token, address indexed bridge, uint8 decimals);
+    event BridgedTokenRemoved(address indexed token);
 
     /**
      * @notice Initializes the JuiceSwap Gateway for Uniswap V3
@@ -189,8 +198,6 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      * @param _wcbtc The address of the Wrapped cBTC contract
      * @param _swapRouter The address of the Uniswap V3 SwapRouter contract
      * @param _positionManager The address of the NonfungiblePositionManager contract
-     * @param _bridgedUsd The address of the bridged stablecoin (e.g., USDT)
-     * @param _stablecoinBridge The address of the StablecoinBridge contract
      */
     constructor(
         address _jusd,
@@ -198,9 +205,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         address _juice,
         address _wcbtc,
         address _swapRouter,
-        address _positionManager,
-        address _bridgedUsd,
-        address _stablecoinBridge
+        address _positionManager
     ) Ownable(msg.sender) {
         JUSD = IERC20(_jusd);
         SV_JUSD = IERC4626(_svJusd);
@@ -209,9 +214,6 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         SWAP_ROUTER = ISwapRouter(_swapRouter);
         POSITION_MANAGER = INonfungiblePositionManager(_positionManager);
         FACTORY = IUniswapV3Factory(INonfungiblePositionManager(_positionManager).factory());
-        BRIDGED_USD = IERC20(_bridgedUsd);
-        STABLECOIN_BRIDGE = IStablecoinBridge(_stablecoinBridge);
-        BRIDGED_USD_DECIMALS = IERC20Metadata(_bridgedUsd).decimals();
         JUSD_DECIMALS = IERC20Metadata(_jusd).decimals();
 
         // Pre-approve tokens for efficiency
@@ -221,10 +223,6 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         IERC20(_svJusd).approve(_positionManager, type(uint256).max);
         IERC20(_wcbtc).approve(_swapRouter, type(uint256).max);
         IERC20(_wcbtc).approve(_positionManager, type(uint256).max);
-        // Approve bridged USD to StablecoinBridge for mint operations
-        IERC20(_bridgedUsd).approve(_stablecoinBridge, type(uint256).max);
-        // Approve JUSD to StablecoinBridge for burn operations (burnAndSend)
-        JUSD.approve(_stablecoinBridge, type(uint256).max);
     }
 
     /**
@@ -556,14 +554,22 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         return JUICE.calculateShares(jusdAmount);
     }
 
-    function bridgedUsdToSvJusd(uint256 usdAmount) external view returns (uint256) {
-        uint256 jusdAmount = _bridgedUsdToJusdAmount(usdAmount);
+    function bridgedToSvJusd(address bridgedToken, uint256 amount) external view returns (uint256) {
+        BridgeConfig storage config = bridgeConfigs[bridgedToken];
+        if (address(config.bridge) == address(0)) revert BridgedTokenNotFound(bridgedToken);
+        uint256 jusdAmount = _bridgedToJusdAmount(amount, config.decimals);
         return SV_JUSD.convertToShares(jusdAmount);
     }
 
-    function svJusdToBridgedUsd(uint256 svJusdAmount) external view returns (uint256) {
+    function svJusdToBridged(address bridgedToken, uint256 svJusdAmount) external view returns (uint256) {
+        BridgeConfig storage config = bridgeConfigs[bridgedToken];
+        if (address(config.bridge) == address(0)) revert BridgedTokenNotFound(bridgedToken);
         uint256 jusdAmount = SV_JUSD.convertToAssets(svJusdAmount);
-        return _jusdToBridgedUsdAmount(jusdAmount);
+        return _jusdToBridgedAmount(jusdAmount, config.decimals);
+    }
+
+    function isBridgedToken(address token) external view returns (bool) {
+        return address(bridgeConfigs[token].bridge) != address(0);
     }
 
     // ==================== Internal Functions ====================
@@ -586,13 +592,17 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             // JUICE cannot be used as input due to Equity flash loan protection.
             // Users must redeem JUICE directly: JUICE.redeem() → then swap the JUSD.
             revert JuiceInputNotSupported();
-        } else if (token == address(BRIDGED_USD)) {
-            // Bridged USD (e.g., USDT) → JUSD (via Bridge) → svJUSD
-            SafeERC20.safeTransferFrom(BRIDGED_USD, msg.sender, address(this), amount);
+        }
+
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[token];
+        if (address(config.bridge) != address(0)) {
+            // Bridged USD (e.g., USDC.e, USDT.e, ctUSD) → JUSD (via Bridge) → svJUSD
+            SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), amount);
             // Bridge mints JUSD (handles decimal conversion internally)
-            STABLECOIN_BRIDGE.mint(amount);
+            config.bridge.mint(amount);
             // Convert bridged USD amount to JUSD amount (e.g., 6 decimals → 18 decimals)
-            uint256 jusdAmount = _bridgedUsdToJusdAmount(amount);
+            uint256 jusdAmount = _bridgedToJusdAmount(amount, config.decimals);
             // Deposit JUSD into savings vault
             uint256 shares = SV_JUSD.deposit(jusdAmount, address(this));
             return (address(SV_JUSD), shares);
@@ -629,13 +639,17 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             uint256 juiceAmount = JUICE.invest(jusdAmount, 0);
             SafeERC20.safeTransfer(IERC20(address(JUICE)), to, juiceAmount);
             return juiceAmount;
-        } else if (token == address(BRIDGED_USD)) {
-            // svJUSD → JUSD → Bridged USD (e.g., USDT)
+        }
+
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[token];
+        if (address(config.bridge) != address(0)) {
+            // svJUSD → JUSD → Bridged USD (e.g., USDC.e, USDT.e, ctUSD)
             uint256 jusdAmount = SV_JUSD.redeem(actualAmount, address(this), address(this));
             // Burn JUSD via bridge to get bridged USD sent to recipient
-            STABLECOIN_BRIDGE.burnAndSend(to, jusdAmount);
+            config.bridge.burnAndSend(to, jusdAmount);
             // Return amount in bridged USD decimals
-            return _jusdToBridgedUsdAmount(jusdAmount);
+            return _jusdToBridgedAmount(jusdAmount, config.decimals);
         } else {
             // Other tokens - direct transfer
             SafeERC20.safeTransfer(IERC20(token), to, actualAmount);
@@ -650,7 +664,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         if (token == NATIVE_TOKEN) return address(WCBTC);
         if (token == address(JUSD)) return address(SV_JUSD);
         if (token == address(JUICE)) return address(SV_JUSD); // JUICE swaps through equity
-        if (token == address(BRIDGED_USD)) return address(SV_JUSD); // Bridged USD converts to svJUSD
+        // Check if token is a bridged stablecoin
+        if (address(bridgeConfigs[token].bridge) != address(0)) return address(SV_JUSD);
         return token;
     }
 
@@ -669,34 +684,34 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     }
 
     /**
-     * @dev Converts bridged USD amount to JUSD amount (e.g., 6 decimals → 18 decimals)
+     * @dev Converts bridged token amount to JUSD amount (e.g., 6 decimals → 18 decimals)
      */
-    function _bridgedUsdToJusdAmount(uint256 bridgedUsdAmount) internal view returns (uint256) {
-        if (BRIDGED_USD_DECIMALS < JUSD_DECIMALS) {
-            return bridgedUsdAmount * 10 ** (JUSD_DECIMALS - BRIDGED_USD_DECIMALS);
-        } else if (BRIDGED_USD_DECIMALS > JUSD_DECIMALS) {
-            return bridgedUsdAmount / 10 ** (BRIDGED_USD_DECIMALS - JUSD_DECIMALS);
+    function _bridgedToJusdAmount(uint256 bridgedAmount, uint8 bridgedDecimals) internal view returns (uint256) {
+        if (bridgedDecimals < JUSD_DECIMALS) {
+            return bridgedAmount * 10 ** (JUSD_DECIMALS - bridgedDecimals);
+        } else if (bridgedDecimals > JUSD_DECIMALS) {
+            return bridgedAmount / 10 ** (bridgedDecimals - JUSD_DECIMALS);
         }
-        return bridgedUsdAmount;
+        return bridgedAmount;
     }
 
     /**
-     * @dev Converts JUSD amount to bridged USD amount (e.g., 18 decimals → 6 decimals)
+     * @dev Converts JUSD amount to bridged token amount (e.g., 18 decimals → 6 decimals)
      */
-    function _jusdToBridgedUsdAmount(uint256 jusdAmount) internal view returns (uint256) {
-        if (JUSD_DECIMALS > BRIDGED_USD_DECIMALS) {
-            return jusdAmount / 10 ** (JUSD_DECIMALS - BRIDGED_USD_DECIMALS);
-        } else if (JUSD_DECIMALS < BRIDGED_USD_DECIMALS) {
-            return jusdAmount * 10 ** (BRIDGED_USD_DECIMALS - JUSD_DECIMALS);
+    function _jusdToBridgedAmount(uint256 jusdAmount, uint8 bridgedDecimals) internal view returns (uint256) {
+        if (JUSD_DECIMALS > bridgedDecimals) {
+            return jusdAmount / 10 ** (JUSD_DECIMALS - bridgedDecimals);
+        } else if (JUSD_DECIMALS < bridgedDecimals) {
+            return jusdAmount * 10 ** (bridgedDecimals - JUSD_DECIMALS);
         }
         return jusdAmount;
     }
 
     /**
-     * @dev Converts bridged USD amount to svJUSD shares
+     * @dev Converts bridged token amount to svJUSD shares
      */
-    function _bridgedUsdToSvJusdAmount(uint256 bridgedUsdAmount) internal view returns (uint256) {
-        uint256 jusdAmount = _bridgedUsdToJusdAmount(bridgedUsdAmount);
+    function _bridgedToSvJusdAmount(uint256 bridgedAmount, uint8 bridgedDecimals) internal view returns (uint256) {
+        uint256 jusdAmount = _bridgedToJusdAmount(bridgedAmount, bridgedDecimals);
         return SV_JUSD.convertToShares(jusdAmount);
     }
 
@@ -706,8 +721,11 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     function _toActualMinAmount(address userToken, uint256 minAmount) internal view returns (uint256) {
         if (userToken == address(JUSD)) {
             return _jusdToSvJusdAmount(minAmount);
-        } else if (userToken == address(BRIDGED_USD)) {
-            return _bridgedUsdToSvJusdAmount(minAmount);
+        }
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[userToken];
+        if (address(config.bridge) != address(0)) {
+            return _bridgedToSvJusdAmount(minAmount, config.decimals);
         }
         return minAmount;
     }
@@ -718,9 +736,12 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     function _toUserAmount(address userToken, uint256 actualAmount) internal view returns (uint256) {
         if (userToken == address(JUSD)) {
             return _svJusdToJusdAmount(actualAmount);
-        } else if (userToken == address(BRIDGED_USD)) {
+        }
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[userToken];
+        if (address(config.bridge) != address(0)) {
             uint256 jusdAmount = _svJusdToJusdAmount(actualAmount);
-            return _jusdToBridgedUsdAmount(jusdAmount);
+            return _jusdToBridgedAmount(jusdAmount, config.decimals);
         }
         return actualAmount;
     }
@@ -750,15 +771,22 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         if (userToken == address(JUSD) && actualToken == address(SV_JUSD)) {
             // Convert excess svJUSD back to JUSD
             SV_JUSD.redeem(excessAmount, to, address(this));
-        } else if (userToken == address(BRIDGED_USD) && actualToken == address(SV_JUSD)) {
-            // Convert excess svJUSD back to bridged USD via JUSD
-            uint256 jusdAmount = SV_JUSD.redeem(excessAmount, address(this), address(this));
-            STABLECOIN_BRIDGE.burnAndSend(to, jusdAmount);
         } else if (userToken == NATIVE_TOKEN && actualToken == address(WCBTC)) {
             // Convert excess WcBTC back to native cBTC
             WCBTC.withdraw(excessAmount);
             (bool success, ) = to.call{value: excessAmount}("");
             if (!success) revert TransferFailed();
+        } else if (actualToken == address(SV_JUSD)) {
+            // Check if userToken is a bridged stablecoin
+            BridgeConfig storage config = bridgeConfigs[userToken];
+            if (address(config.bridge) != address(0)) {
+                // Convert excess svJUSD back to bridged USD via JUSD
+                uint256 jusdAmount = SV_JUSD.redeem(excessAmount, address(this), address(this));
+                config.bridge.burnAndSend(to, jusdAmount);
+            } else {
+                // Return excess svJUSD directly (shouldn't happen in normal flow)
+                SafeERC20.safeTransfer(IERC20(actualToken), to, excessAmount);
+            }
         } else if (actualToken != address(0)) {
             // Return excess tokens directly
             SafeERC20.safeTransfer(IERC20(actualToken), to, excessAmount);
@@ -780,6 +808,70 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         uint24 oldFee = defaultFee;
         defaultFee = newFee;
         emit DefaultFeeUpdated(oldFee, newFee);
+    }
+
+    /**
+     * @notice Adds a bridged stablecoin that can be converted to JUSD via its bridge
+     * @param token The bridged stablecoin address (e.g., USDC.e, USDT.e, ctUSD)
+     * @param bridge The StablecoinBridge contract for this token
+     */
+    function addBridgedToken(address token, address bridge) external onlyOwner {
+        if (token == address(0) || bridge == address(0)) revert InvalidBridgeConfig();
+        if (bridgeConfigs[token].bridge != IStablecoinBridge(address(0))) {
+            revert BridgedTokenAlreadyExists(token);
+        }
+
+        uint8 decimals = IERC20Metadata(token).decimals();
+        bridgeConfigs[token] = BridgeConfig({
+            bridge: IStablecoinBridge(bridge),
+            decimals: decimals
+        });
+        bridgedTokens.push(token);
+
+        // Approve bridged token to bridge for mint operations
+        IERC20(token).approve(bridge, type(uint256).max);
+        // Approve JUSD to bridge for burn operations
+        JUSD.approve(bridge, type(uint256).max);
+
+        emit BridgedTokenAdded(token, bridge, decimals);
+    }
+
+    /**
+     * @notice Removes a bridged stablecoin from the supported list
+     * @param token The bridged stablecoin address to remove
+     */
+    function removeBridgedToken(address token) external onlyOwner {
+        if (bridgeConfigs[token].bridge == IStablecoinBridge(address(0))) {
+            revert BridgedTokenNotFound(token);
+        }
+
+        address bridge = address(bridgeConfigs[token].bridge);
+
+        // Remove from mapping
+        delete bridgeConfigs[token];
+
+        // Remove from array (swap with last element and pop)
+        uint256 length = bridgedTokens.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (bridgedTokens[i] == token) {
+                bridgedTokens[i] = bridgedTokens[length - 1];
+                bridgedTokens.pop();
+                break;
+            }
+        }
+
+        // Revoke approvals
+        IERC20(token).approve(bridge, 0);
+        // Note: We don't revoke JUSD approval as other bridges may still need it
+
+        emit BridgedTokenRemoved(token);
+    }
+
+    /**
+     * @notice Returns all supported bridged tokens
+     */
+    function getBridgedTokens() external view returns (address[] memory) {
+        return bridgedTokens;
     }
 
     /**

--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -575,6 +575,75 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         return address(bridgeConfigs[token].bridge) != address(0);
     }
 
+    /**
+     * @notice Returns comprehensive status information for a bridged token's bridge
+     * @dev Useful for frontends to check if operations will succeed before attempting them
+     * @param bridgedToken The bridged stablecoin address to check
+     * @return status The bridge status containing mint/burn capacity and block reasons
+     */
+    function getBridgeStatus(address bridgedToken) external view returns (BridgeStatus memory status) {
+        BridgeConfig storage config = bridgeConfigs[bridgedToken];
+
+        // Check if token is supported
+        if (address(config.bridge) == address(0)) {
+            return BridgeStatus({
+                canMint: false,
+                canBurn: false,
+                mintCapacity: 0,
+                burnCapacity: 0,
+                mintBlockReason: "Token not supported",
+                burnBlockReason: "Token not supported"
+            });
+        }
+
+        IStablecoinBridge bridge = config.bridge;
+
+        // === MINT CHECKS (bridged token → JUSD) ===
+        bool canMint = true;
+        string memory mintReason = "";
+        uint256 mintCapacity = 0;
+
+        // Check if bridge is stopped
+        if (bridge.stopped()) {
+            canMint = false;
+            mintReason = "Bridge stopped";
+        }
+        // Check if bridge is expired
+        else if (block.timestamp > bridge.horizon()) {
+            canMint = false;
+            mintReason = "Bridge expired";
+        }
+        // Check mint limit
+        else {
+            uint256 minted = bridge.minted();
+            uint256 limit = bridge.limit();
+            if (minted >= limit) {
+                canMint = false;
+                mintReason = "Limit reached";
+            } else {
+                // Remaining capacity in JUSD (18 decimals)
+                mintCapacity = limit - minted;
+            }
+        }
+
+        // === BURN CHECKS (JUSD → bridged token) ===
+        // Burn needs the bridge to have sufficient bridged token balance
+        address usdToken = bridge.usd();
+        uint256 bridgeBalance = IERC20(usdToken).balanceOf(address(bridge));
+
+        bool canBurn = bridgeBalance > 0;
+        string memory burnReason = canBurn ? "" : "Insufficient bridge liquidity";
+
+        return BridgeStatus({
+            canMint: canMint,
+            canBurn: canBurn,
+            mintCapacity: mintCapacity,
+            burnCapacity: bridgeBalance,  // In bridged token decimals
+            mintBlockReason: mintReason,
+            burnBlockReason: burnReason
+        });
+    }
+
     // ==================== Internal Functions ====================
 
     /**

--- a/contracts/interfaces/IJuiceSwapGateway.sol
+++ b/contracts/interfaces/IJuiceSwapGateway.sol
@@ -204,4 +204,18 @@ interface IJuiceSwapGateway {
      * @return juiceAmount The amount of JUICE received
      */
     function jusdToJuice(uint256 jusdAmount) external view returns (uint256 juiceAmount);
+
+    /**
+     * @notice Returns the equivalent amount of svJUSD for a given amount of bridged stablecoin (e.g., USDT)
+     * @param usdAmount The amount of bridged stablecoin (in its native decimals, e.g., 6 for USDT)
+     * @return svJusdAmount The equivalent amount of svJUSD
+     */
+    function bridgedUsdToSvJusd(uint256 usdAmount) external view returns (uint256 svJusdAmount);
+
+    /**
+     * @notice Returns the equivalent amount of bridged stablecoin for a given amount of svJUSD
+     * @param svJusdAmount The amount of svJUSD
+     * @return usdAmount The equivalent amount of bridged stablecoin (in its native decimals)
+     */
+    function svJusdToBridgedUsd(uint256 svJusdAmount) external view returns (uint256 usdAmount);
 }

--- a/contracts/interfaces/IJuiceSwapGateway.sol
+++ b/contracts/interfaces/IJuiceSwapGateway.sol
@@ -206,16 +206,44 @@ interface IJuiceSwapGateway {
     function jusdToJuice(uint256 jusdAmount) external view returns (uint256 juiceAmount);
 
     /**
-     * @notice Returns the equivalent amount of svJUSD for a given amount of bridged stablecoin (e.g., USDT)
-     * @param usdAmount The amount of bridged stablecoin (in its native decimals, e.g., 6 for USDT)
+     * @notice Returns the equivalent amount of svJUSD for a given amount of bridged stablecoin
+     * @param bridgedToken The bridged stablecoin address (e.g., USDC.e, USDT.e, ctUSD)
+     * @param amount The amount of bridged stablecoin (in its native decimals)
      * @return svJusdAmount The equivalent amount of svJUSD
      */
-    function bridgedUsdToSvJusd(uint256 usdAmount) external view returns (uint256 svJusdAmount);
+    function bridgedToSvJusd(address bridgedToken, uint256 amount) external view returns (uint256 svJusdAmount);
 
     /**
      * @notice Returns the equivalent amount of bridged stablecoin for a given amount of svJUSD
+     * @param bridgedToken The bridged stablecoin address (e.g., USDC.e, USDT.e, ctUSD)
      * @param svJusdAmount The amount of svJUSD
-     * @return usdAmount The equivalent amount of bridged stablecoin (in its native decimals)
+     * @return amount The equivalent amount of bridged stablecoin (in its native decimals)
      */
-    function svJusdToBridgedUsd(uint256 svJusdAmount) external view returns (uint256 usdAmount);
+    function svJusdToBridged(address bridgedToken, uint256 svJusdAmount) external view returns (uint256 amount);
+
+    /**
+     * @notice Checks if a token is a supported bridged stablecoin
+     * @param token The token address to check
+     * @return True if the token is a supported bridged stablecoin
+     */
+    function isBridgedToken(address token) external view returns (bool);
+
+    /**
+     * @notice Returns all supported bridged tokens
+     * @return Array of bridged token addresses
+     */
+    function getBridgedTokens() external view returns (address[] memory);
+
+    /**
+     * @notice Adds a bridged stablecoin that can be converted to JUSD via its bridge
+     * @param token The bridged stablecoin address
+     * @param bridge The StablecoinBridge contract for this token
+     */
+    function addBridgedToken(address token, address bridge) external;
+
+    /**
+     * @notice Removes a bridged stablecoin from the supported list
+     * @param token The bridged stablecoin address to remove
+     */
+    function removeBridgedToken(address token) external;
 }

--- a/contracts/interfaces/IJuiceSwapGateway.sol
+++ b/contracts/interfaces/IJuiceSwapGateway.sol
@@ -8,8 +8,18 @@ pragma solidity ^0.8.20;
  *      - JUSD ↔ svJUSD conversions (for interest-bearing liquidity)
  *      - JUICE ↔ JUSD conversions (via Equity contract)
  *      - cBTC ↔ WcBTC wrapping
+ *      - Bridged stablecoins ↔ JUSD conversions (via StablecoinBridge)
  */
 interface IJuiceSwapGateway {
+    /// @notice Status information for a bridged stablecoin's bridge
+    struct BridgeStatus {
+        bool canMint;           // Can deposit bridged token (mint JUSD)?
+        bool canBurn;           // Can withdraw to bridged token (burn JUSD)?
+        uint256 mintCapacity;   // Remaining JUSD that can be minted (in JUSD decimals)
+        uint256 burnCapacity;   // Available bridged token for burns (in bridged token decimals)
+        string mintBlockReason; // Reason why minting is blocked (empty if canMint)
+        string burnBlockReason; // Reason why burning is blocked (empty if canBurn)
+    }
     /**
      * @notice Emitted when a swap is executed through the gateway
      * @param user The address that initiated the swap
@@ -246,4 +256,19 @@ interface IJuiceSwapGateway {
      * @param token The bridged stablecoin address to remove
      */
     function removeBridgedToken(address token) external;
+
+    /**
+     * @notice Returns comprehensive status information for a bridged token's bridge
+     * @dev Useful for frontends to check if operations will succeed before attempting them.
+     *      Checks include: bridge stopped, bridge expired, mint limit reached, burn liquidity.
+     * @param bridgedToken The bridged stablecoin address to check
+     * @return status The bridge status containing:
+     *         - canMint: Whether deposits (bridged → JUSD) are possible
+     *         - canBurn: Whether withdrawals (JUSD → bridged) are possible
+     *         - mintCapacity: Remaining JUSD mintable through this bridge
+     *         - burnCapacity: Available bridged tokens in bridge for withdrawals
+     *         - mintBlockReason: Human-readable reason if minting blocked
+     *         - burnBlockReason: Human-readable reason if burning blocked
+     */
+    function getBridgeStatus(address bridgedToken) external view returns (BridgeStatus memory status);
 }

--- a/contracts/interfaces/IStablecoinBridge.sol
+++ b/contracts/interfaces/IStablecoinBridge.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IStablecoinBridge
+ * @notice Interface for the StablecoinBridge contract that enables 1:1 conversion
+ *         between a trusted stablecoin (e.g., USDT) and JUSD.
+ */
+interface IStablecoinBridge {
+    /**
+     * @notice Mint JUSD by depositing source stablecoin (e.g., USDT)
+     * @param amount The amount of source stablecoin to convert
+     */
+    function mint(uint256 amount) external;
+
+    /**
+     * @notice Mint JUSD to a specific address
+     * @param target The address to receive JUSD
+     * @param amount The amount of source stablecoin to convert
+     */
+    function mintTo(address target, uint256 amount) external;
+
+    /**
+     * @notice Burn JUSD and receive source stablecoin
+     * @param amount The amount of JUSD to burn
+     */
+    function burn(uint256 amount) external;
+
+    /**
+     * @notice Burn JUSD and send source stablecoin to a specific address
+     * @param target The address to receive the source stablecoin
+     * @param amount The amount of JUSD to burn
+     */
+    function burnAndSend(address target, uint256 amount) external;
+
+    /**
+     * @notice Check if the bridge has been permanently stopped
+     */
+    function stopped() external view returns (bool);
+
+    /**
+     * @notice The expiration timestamp after which minting is disabled
+     */
+    function horizon() external view returns (uint256);
+
+    /**
+     * @notice The maximum amount of JUSD that can be minted through this bridge
+     */
+    function limit() external view returns (uint256);
+
+    /**
+     * @notice The current amount of JUSD minted through this bridge
+     */
+    function minted() external view returns (uint256);
+
+    /**
+     * @notice The source stablecoin token (e.g., USDT)
+     */
+    function usd() external view returns (address);
+
+    /**
+     * @notice The JUSD token
+     */
+    function JUSD() external view returns (address);
+}

--- a/contracts/mocks/MockStablecoinBridge.sol
+++ b/contracts/mocks/MockStablecoinBridge.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IMockJUSD is IERC20 {
+    function mint(address to, uint256 amount) external;
+    function burn(address from, uint256 amount) external;
+}
+
+/**
+ * @title MockStablecoinBridge
+ * @notice Mock bridge for testing bridged stablecoin conversions
+ * @dev Simulates 1:1 conversion between a bridged stablecoin (e.g., USDT) and JUSD
+ */
+contract MockStablecoinBridge {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable usd;
+    IMockJUSD public immutable JUSD;
+    uint8 private immutable usdDecimals;
+    uint8 private immutable jusdDecimals;
+
+    uint256 public immutable horizon;
+    uint256 public immutable limit;
+    uint256 public minted;
+    bool public stopped;
+
+    error Stopped();
+    error Expired();
+    error LimitExceeded();
+
+    constructor(address _usd, address _jusd, uint256 _limit, uint256 _weeks) {
+        usd = IERC20(_usd);
+        JUSD = IMockJUSD(_jusd);
+        usdDecimals = IERC20Metadata(_usd).decimals();
+        jusdDecimals = IERC20Metadata(_jusd).decimals();
+        horizon = block.timestamp + _weeks * 1 weeks;
+        limit = _limit;
+    }
+
+    function mint(uint256 amount) external {
+        mintTo(msg.sender, amount);
+    }
+
+    function mintTo(address target, uint256 amount) public {
+        if (stopped) revert Stopped();
+        if (block.timestamp > horizon) revert Expired();
+
+        usd.safeTransferFrom(msg.sender, address(this), amount);
+
+        uint256 jusdAmount = _convertAmount(amount, usdDecimals, jusdDecimals);
+        minted += jusdAmount;
+        if (minted > limit) revert LimitExceeded();
+
+        JUSD.mint(target, jusdAmount);
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, msg.sender, amount);
+    }
+
+    function burnAndSend(address target, uint256 amount) external {
+        _burn(msg.sender, target, amount);
+    }
+
+    function _burn(address jusdHolder, address target, uint256 amount) internal {
+        uint256 usdAmount = _convertAmount(amount, jusdDecimals, usdDecimals);
+
+        JUSD.burn(jusdHolder, amount);
+        usd.safeTransfer(target, usdAmount);
+        minted -= amount;
+    }
+
+    function _convertAmount(uint256 amount, uint8 fromDecimals, uint8 toDecimals) internal pure returns (uint256) {
+        if (fromDecimals < toDecimals) {
+            return amount * 10 ** (toDecimals - fromDecimals);
+        } else if (fromDecimals > toDecimals) {
+            return amount / 10 ** (fromDecimals - toDecimals);
+        }
+        return amount;
+    }
+
+    // Test helpers
+    function setMinted(uint256 _minted) external {
+        minted = _minted;
+    }
+
+    function setStopped(bool _stopped) external {
+        stopped = _stopped;
+    }
+}

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -2663,6 +2663,29 @@ describe("JuiceSwapGateway", function () {
         expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.false;
       });
 
+      it("Should revoke both token and JUSD approvals when removing bridged token", async function () {
+        const { gateway, owner, usdc, usdt, usdcBridge, usdtBridge, jusd } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const gatewayAddress = await gateway.getAddress();
+        const usdcBridgeAddress = await usdcBridge.getAddress();
+        const usdtBridgeAddress = await usdtBridge.getAddress();
+
+        // Verify both bridges have unlimited JUSD approval before removal
+        expect(await jusd.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(ethers.MaxUint256);
+        expect(await jusd.allowance(gatewayAddress, usdtBridgeAddress)).to.equal(ethers.MaxUint256);
+
+        // Remove USDC bridge
+        await gateway.connect(owner).removeBridgedToken(await usdc.getAddress());
+
+        // Verify USDC bridge approvals are revoked
+        expect(await usdc.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(0);
+        expect(await jusd.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(0);
+
+        // Verify USDT bridge approvals remain unaffected
+        expect(await jusd.allowance(gatewayAddress, usdtBridgeAddress)).to.equal(ethers.MaxUint256);
+      });
+
       it("Should revert when removing non-existent bridged token", async function () {
         const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
 

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -2750,6 +2750,55 @@ describe("JuiceSwapGateway", function () {
           )
         ).to.be.revertedWithCustomError(gateway, "TooManyBridgedTokens");
       });
+
+      it("Should revert with InvalidBridgeConfig when bridge.usd() != token", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+
+        // Deploy a token and a bridge for a DIFFERENT token
+        const wrongToken = await MockERC20Factory.deploy("Wrong", "WRONG", 6);
+        const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+        const bridge = await MockBridgeFactory.deploy(
+          await usdc.getAddress(),  // Bridge expects USDC
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        // Try to add wrongToken with a bridge configured for USDC
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await wrongToken.getAddress(),
+            await bridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
+      });
+
+      it("Should revert with InvalidBridgeConfig when bridge.JUSD() != gateway JUSD", async function () {
+        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+
+        // Deploy a bridge pointing to a different JUSD
+        const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+        const fakeJusd = await MockERC20Factory.deploy("Fake JUSD", "FJUSD", 18);
+        const bridge = await MockBridgeFactory.deploy(
+          await usdc.getAddress(),
+          await fakeJusd.getAddress(),  // Wrong JUSD
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await usdc.getAddress(),
+            await bridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
+      });
     });
 
     describe("Swap with Bridged Tokens", function () {

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -2689,6 +2689,44 @@ describe("JuiceSwapGateway", function () {
           gateway.connect(owner).addBridgedToken(ethers.ZeroAddress, ethers.ZeroAddress)
         ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
       });
+
+      it("Should revert with TooManyBridgedTokens when limit exceeded", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+
+        // Already have 3 tokens, add 7 more to reach limit of 10
+        for (let i = 0; i < 7; i++) {
+          const token = await MockERC20Factory.deploy(`Token${i}`, `TKN${i}`, 6);
+          const bridge = await MockBridgeFactory.deploy(
+            await token.getAddress(),
+            await jusd.getAddress(),
+            BRIDGE_LIMIT,
+            BRIDGE_WEEKS
+          );
+          await gateway.connect(owner).addBridgedToken(
+            await token.getAddress(),
+            await bridge.getAddress()
+          );
+        }
+
+        // 11th token should fail
+        const extraToken = await MockERC20Factory.deploy("Extra", "EXTRA", 6);
+        const extraBridge = await MockBridgeFactory.deploy(
+          await extraToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await extraToken.getAddress(),
+            await extraBridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "TooManyBridgedTokens");
+      });
     });
 
     describe("Swap with Bridged Tokens", function () {

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -3049,5 +3049,163 @@ describe("JuiceSwapGateway", function () {
         expect(tokens.length).to.equal(3);
       });
     });
+
+    describe("getBridgeStatus", function () {
+      const bridgeAmount = 10_000_000n * 10n ** 6n; // 10M with 6 decimals (from fixture)
+
+      it("Should return healthy status for properly configured bridge", async function () {
+        const { gateway, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.true;
+        expect(status.canBurn).to.be.true;
+        expect(status.mintCapacity).to.equal(BRIDGE_LIMIT);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return unsupported status for unknown token", async function () {
+        const { gateway } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Use a random address that's not a bridged token
+        const randomAddress = ethers.Wallet.createRandom().address;
+        const status = await gateway.getBridgeStatus(randomAddress);
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.false;
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(0);
+        expect(status.mintBlockReason).to.equal("Token not supported");
+        expect(status.burnBlockReason).to.equal("Token not supported");
+      });
+
+      it("Should return stopped status when bridge is stopped", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Stop the bridge
+        await usdcBridge.setStopped(true);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.true; // Burn should still work
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(bridgeAmount); // Bridge still has liquidity
+        expect(status.mintBlockReason).to.equal("Bridge stopped");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return expired status when bridge horizon is passed", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Get the bridge horizon and advance time past it
+        const horizon = await usdcBridge.horizon();
+        await time.increaseTo(horizon + 1n);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.true; // Burn should still work
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("Bridge expired");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return limit reached when mint limit is exhausted", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Set minted to the limit
+        await usdcBridge.setMinted(BRIDGE_LIMIT);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.true; // Burn should still work
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("Limit reached");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return insufficient liquidity when bridge has no tokens", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        // Deploy a new bridged token with empty bridge
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        // Add to gateway but don't fund the bridge
+        await gateway.connect(owner).addBridgedToken(await newToken.getAddress(), await newBridge.getAddress());
+
+        const status = await gateway.getBridgeStatus(await newToken.getAddress());
+
+        expect(status.canMint).to.be.true; // Can still mint
+        expect(status.canBurn).to.be.false; // Can't burn without liquidity
+        expect(status.mintCapacity).to.equal(BRIDGE_LIMIT);
+        expect(status.burnCapacity).to.equal(0);
+        expect(status.mintBlockReason).to.equal("");
+        expect(status.burnBlockReason).to.equal("Insufficient bridge liquidity");
+      });
+
+      it("Should return accurate remaining mint capacity", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Set minted to 40% of limit
+        const mintedAmount = BRIDGE_LIMIT * 40n / 100n;
+        await usdcBridge.setMinted(mintedAmount);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.true;
+        expect(status.canBurn).to.be.true;
+        expect(status.mintCapacity).to.equal(BRIDGE_LIMIT - mintedAmount);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should handle combined failure: stopped bridge with no liquidity", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        // Deploy a new bridged token with empty bridge
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        // Add to gateway but don't fund the bridge
+        await gateway.connect(owner).addBridgedToken(await newToken.getAddress(), await newBridge.getAddress());
+
+        // Stop the bridge
+        await newBridge.setStopped(true);
+
+        const status = await gateway.getBridgeStatus(await newToken.getAddress());
+
+        // Both mint and burn should be blocked for different reasons
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.false;
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(0);
+        expect(status.mintBlockReason).to.equal("Bridge stopped");
+        expect(status.burnBlockReason).to.equal("Insufficient bridge liquidity");
+      });
+    });
   });
 });

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -9,6 +9,7 @@ import {
   MockWETH,
   MockSwapRouter,
   MockPositionManager,
+  MockStablecoinBridge,
 } from "../typechain-types";
 import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
@@ -2476,6 +2477,539 @@ describe("JuiceSwapGateway", function () {
           anyValue,
           tokenId  // Verify correct tokenId is emitted
         );
+    });
+  });
+
+  describe("Bridged Token Support", function () {
+    const BRIDGE_LIMIT = ethers.parseEther("100000000"); // 100M JUSD
+    const BRIDGE_WEEKS = 208; // 4 years
+
+    /**
+     * Deploy gateway with bridged token support (standalone fixture)
+     */
+    async function deployGatewayWithBridgedTokensFixture() {
+      const [owner, user1, user2, feeCollector] = await ethers.getSigners();
+
+      // Deploy core mocks
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const jusd = (await MockERC20Factory.deploy("JuiceDollar", "JUSD", 18)) as unknown as MockERC20;
+
+      const MockEquityFactory = await ethers.getContractFactory("MockEquity");
+      const juice = (await MockEquityFactory.deploy("Juice Protocol", "JUICE", await jusd.getAddress())) as unknown as MockEquity;
+
+      const MockERC4626Factory = await ethers.getContractFactory("MockERC4626");
+      const svJusd = (await MockERC4626Factory.deploy(await jusd.getAddress(), "Savings Vault JUSD", "svJUSD")) as unknown as MockERC4626;
+
+      const MockWETHFactory = await ethers.getContractFactory("MockWETH");
+      const wcbtc = (await MockWETHFactory.deploy("Wrapped cBTC", "WcBTC")) as unknown as MockWETH;
+
+      const MockSwapRouterFactory = await ethers.getContractFactory("MockSwapRouter");
+      const swapRouter = (await MockSwapRouterFactory.deploy()) as unknown as MockSwapRouter;
+
+      const MockPositionManagerFactory = await ethers.getContractFactory("MockPositionManager");
+      const positionManager = (await MockPositionManagerFactory.deploy()) as unknown as MockPositionManager;
+
+      // Deploy gateway
+      const JuiceSwapGatewayFactory = await ethers.getContractFactory("JuiceSwapGateway");
+      const gateway = (await JuiceSwapGatewayFactory.deploy(
+        await jusd.getAddress(),
+        await svJusd.getAddress(),
+        await juice.getAddress(),
+        await wcbtc.getAddress(),
+        await swapRouter.getAddress(),
+        await positionManager.getAddress()
+      )) as unknown as JuiceSwapGateway;
+
+      // Setup balances
+      await jusd.mint(user1.address, INITIAL_BALANCE);
+      await jusd.mint(user2.address, INITIAL_BALANCE);
+      await juice.mint(user1.address, INITIAL_BALANCE);
+      await wcbtc.connect(user1).deposit({ value: ethers.parseEther("100") });
+      await wcbtc.connect(user2).deposit({ value: ethers.parseEther("100") });
+      await jusd.mint(await svJusd.getAddress(), ethers.parseEther("100000"));
+      await jusd.mint(await juice.getAddress(), ethers.parseEther("10000"));
+
+      // Deploy bridged stablecoins (6 decimals like USDT/USDC)
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC.e", 6)) as unknown as MockERC20;
+      const usdt = (await MockERC20Factory.deploy("Tether USD", "USDT.e", 6)) as unknown as MockERC20;
+      const ctUsd = (await MockERC20Factory.deploy("M0 USD", "ctUSD", 6)) as unknown as MockERC20;
+
+      // Deploy bridges
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = (await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        BRIDGE_LIMIT,
+        BRIDGE_WEEKS
+      )) as unknown as MockStablecoinBridge;
+      const usdtBridge = (await MockBridgeFactory.deploy(
+        await usdt.getAddress(),
+        await jusd.getAddress(),
+        BRIDGE_LIMIT,
+        BRIDGE_WEEKS
+      )) as unknown as MockStablecoinBridge;
+      const ctUsdBridge = (await MockBridgeFactory.deploy(
+        await ctUsd.getAddress(),
+        await jusd.getAddress(),
+        BRIDGE_LIMIT,
+        BRIDGE_WEEKS
+      )) as unknown as MockStablecoinBridge;
+
+      // Fund bridges with bridged tokens (for burn operations)
+      const bridgeAmount = 10_000_000n * 10n ** 6n; // 10M with 6 decimals
+      await usdc.mint(await usdcBridge.getAddress(), bridgeAmount);
+      await usdt.mint(await usdtBridge.getAddress(), bridgeAmount);
+      await ctUsd.mint(await ctUsdBridge.getAddress(), bridgeAmount);
+
+      // Mint bridged tokens to users
+      const userAmount = 100_000n * 10n ** 6n; // 100k with 6 decimals
+      await usdc.mint(user1.address, userAmount);
+      await usdt.mint(user1.address, userAmount);
+      await ctUsd.mint(user1.address, userAmount);
+
+      // Add bridged tokens to gateway
+      await gateway.connect(owner).addBridgedToken(await usdc.getAddress(), await usdcBridge.getAddress());
+      await gateway.connect(owner).addBridgedToken(await usdt.getAddress(), await usdtBridge.getAddress());
+      await gateway.connect(owner).addBridgedToken(await ctUsd.getAddress(), await ctUsdBridge.getAddress());
+
+      return {
+        owner,
+        user1,
+        user2,
+        feeCollector,
+        jusd,
+        juice,
+        svJusd,
+        wcbtc,
+        swapRouter,
+        positionManager,
+        gateway,
+        usdc,
+        usdt,
+        ctUsd,
+        usdcBridge,
+        usdtBridge,
+        ctUsdBridge,
+      };
+    }
+
+    describe("Admin Functions", function () {
+      it("Should add bridged token", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await newToken.getAddress(),
+            await newBridge.getAddress()
+          )
+        ).to.emit(gateway, "BridgedTokenAdded")
+          .withArgs(await newToken.getAddress(), await newBridge.getAddress(), 6);
+
+        expect(await gateway.isBridgedToken(await newToken.getAddress())).to.be.true;
+      });
+
+      it("Should revert when adding duplicate bridged token", async function () {
+        const { gateway, owner, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await usdc.getAddress(),
+            await usdcBridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenAlreadyExists");
+      });
+
+      it("Should revert when non-owner adds bridged token", async function () {
+        const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(user1).addBridgedToken(
+            await newToken.getAddress(),
+            await newBridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "OwnableUnauthorizedAccount");
+      });
+
+      it("Should remove bridged token", async function () {
+        const { gateway, owner, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.connect(owner).removeBridgedToken(await usdc.getAddress())
+        ).to.emit(gateway, "BridgedTokenRemoved")
+          .withArgs(await usdc.getAddress());
+
+        expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.false;
+      });
+
+      it("Should revert when removing non-existent bridged token", async function () {
+        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const randomAddress = ethers.Wallet.createRandom().address;
+        await expect(
+          gateway.connect(owner).removeBridgedToken(randomAddress)
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+      });
+
+      it("Should return all bridged tokens", async function () {
+        const { gateway, usdc, usdt, ctUsd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const tokens = await gateway.getBridgedTokens();
+        expect(tokens.length).to.equal(3);
+        expect(tokens).to.include(await usdc.getAddress());
+        expect(tokens).to.include(await usdt.getAddress());
+        expect(tokens).to.include(await ctUsd.getAddress());
+      });
+
+      it("Should revert with InvalidBridgeConfig for zero addresses", async function () {
+        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(ethers.ZeroAddress, ethers.ZeroAddress)
+        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
+      });
+    });
+
+    describe("Swap with Bridged Tokens", function () {
+      it("Should swap bridged token (USDC.e) to WcBTC", async function () {
+        const { gateway, user1, usdc, wcbtc, swapRouter } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
+        const expectedOutput = ethers.parseEther("0.01"); // 0.01 WcBTC
+
+        await swapRouter.setSwapOutput(expectedOutput);
+        await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        const wcbtcBefore = await wcbtc.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await wcbtc.getAddress(),
+          0, // use default fee
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const wcbtcAfter = await wcbtc.balanceOf(user1.address);
+        expect(wcbtcAfter - wcbtcBefore).to.equal(expectedOutput);
+      });
+
+      it("Should swap WcBTC to bridged token (USDT.e)", async function () {
+        const { gateway, user1, usdt, wcbtc, svJusd, swapRouter, usdtBridge } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("0.01"); // 0.01 WcBTC
+        const svJusdOutput = ethers.parseEther("1000"); // Mock router returns this
+
+        await swapRouter.setSwapOutput(svJusdOutput);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        // Track bridge minted amount for the burn
+        await usdtBridge.setMinted(svJusdOutput);
+
+        const usdtBefore = await usdt.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await wcbtc.getAddress(),
+          await usdt.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const usdtAfter = await usdt.balanceOf(user1.address);
+        // 1000 JUSD (18 decimals) = 1000 USDT (6 decimals)
+        expect(usdtAfter - usdtBefore).to.equal(1000n * 10n ** 6n);
+      });
+
+      it("Should emit SwapExecuted event with bridged token addresses", async function () {
+        const { gateway, user1, usdc, wcbtc, swapRouter } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = 1000n * 10n ** 6n;
+
+        await swapRouter.setSwapOutput(ethers.parseEther("0.01"));
+        await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        await expect(
+          gateway.connect(user1).swapExactTokensForTokens(
+            await usdc.getAddress(),
+            await wcbtc.getAddress(),
+            0,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          )
+        ).to.emit(gateway, "SwapExecuted")
+          .withArgs(user1.address, await usdc.getAddress(), await wcbtc.getAddress(), anyValue, anyValue);
+      });
+    });
+
+    describe("Add Liquidity with Bridged Tokens", function () {
+      it("Should add liquidity with bridged token (USDC.e) + WcBTC", async function () {
+        const { gateway, user1, usdc, wcbtc, svJusd, positionManager } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const usdcAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
+        const wcbtcAmount = ethers.parseEther("0.01");
+
+        // Calculate expected svJUSD shares (1000 USDC = 1000 JUSD = ~1000 svJUSD shares)
+        const jusdEquivalent = ethers.parseEther("1000"); // 1000 USDC = 1000 JUSD
+        const svJusdShares = await svJusd.convertToShares(jusdEquivalent);
+
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const [amount0, amount1] = svJusdAddr < wcbtcAddr
+          ? [svJusdShares, wcbtcAmount]
+          : [wcbtcAmount, svJusdShares];
+
+        await positionManager.setMintResult(1, 100, amount0, amount1);
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+        const tx = await gateway.connect(user1).addLiquidity(
+          await usdc.getAddress(),
+          await wcbtc.getAddress(),
+          0, // default fee
+          usdcAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+        await expect(tx)
+          .to.emit(gateway, "LiquidityAdded")
+          .withArgs(user1.address, await usdc.getAddress(), await wcbtc.getAddress(), anyValue, anyValue, 1);
+      });
+
+      it("Should revert with InvalidTokenPair for bridged token + JUSD", async function () {
+        const { gateway, user1, usdc, jusd } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const amount = 1000n * 10n ** 6n;
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), amount);
+        await jusd.connect(user1).approve(await gateway.getAddress(), ethers.parseEther("1000"));
+
+        await expect(
+          gateway.connect(user1).addLiquidity(
+            await usdc.getAddress(),
+            await jusd.getAddress(),
+            0,
+            amount,
+            ethers.parseEther("1000"),
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+      });
+
+      it("Should revert with InvalidTokenPair for two bridged tokens", async function () {
+        const { gateway, user1, usdc, usdt } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const amount = 1000n * 10n ** 6n;
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), amount);
+        await usdt.connect(user1).approve(await gateway.getAddress(), amount);
+
+        await expect(
+          gateway.connect(user1).addLiquidity(
+            await usdc.getAddress(),
+            await usdt.getAddress(),
+            0,
+            amount,
+            amount,
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+      });
+    });
+
+    describe("View Functions", function () {
+      it("Should convert bridged token amount to svJUSD", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const usdcAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
+        const jusdEquivalent = ethers.parseEther("1000"); // 1000 JUSD (18 decimals)
+        const expectedSvJusd = await svJusd.convertToShares(jusdEquivalent);
+
+        const result = await gateway.bridgedToSvJusd(await usdc.getAddress(), usdcAmount);
+        expect(result).to.equal(expectedSvJusd);
+      });
+
+      it("Should convert svJUSD amount to bridged token", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const svJusdAmount = ethers.parseEther("1000");
+        const jusdEquivalent = await svJusd.convertToAssets(svJusdAmount);
+        // 1000 JUSD (18 decimals) = 1000 USDC (6 decimals)
+        const expectedUsdc = 1000n * 10n ** 6n;
+
+        const result = await gateway.svJusdToBridged(await usdc.getAddress(), svJusdAmount);
+        expect(result).to.equal(expectedUsdc);
+      });
+
+      it("Should return true for supported bridged token", async function () {
+        const { gateway, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+        expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.true;
+      });
+
+      it("Should return false for non-bridged token", async function () {
+        const { gateway, wcbtc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+        expect(await gateway.isBridgedToken(await wcbtc.getAddress())).to.be.false;
+      });
+
+      it("Should revert bridgedToSvJusd for non-bridged token", async function () {
+        const { gateway, wcbtc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.bridgedToSvJusd(await wcbtc.getAddress(), 1000)
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+      });
+
+      it("Should revert svJusdToBridged for non-bridged token", async function () {
+        const { gateway, wcbtc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.svJusdToBridged(await wcbtc.getAddress(), ethers.parseEther("1000"))
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+      });
+    });
+
+    describe("Decimal Conversion", function () {
+      it("Should correctly convert 6 decimal token to 18 decimal JUSD", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // 1 USDC (6 decimals) = 1 JUSD (18 decimals)
+        const usdcAmount = 1n * 10n ** 6n; // 1 USDC
+        const expectedJusdEquivalent = ethers.parseEther("1"); // 1 JUSD
+        const expectedSvJusd = await svJusd.convertToShares(expectedJusdEquivalent);
+
+        const result = await gateway.bridgedToSvJusd(await usdc.getAddress(), usdcAmount);
+        expect(result).to.equal(expectedSvJusd);
+      });
+
+      it("Should correctly convert 18 decimal JUSD to 6 decimal token", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // 1 JUSD (18 decimals) = 1 USDC (6 decimals)
+        const svJusdAmount = await svJusd.convertToShares(ethers.parseEther("1"));
+        const expectedUsdc = 1n * 10n ** 6n; // 1 USDC
+
+        const result = await gateway.svJusdToBridged(await usdc.getAddress(), svJusdAmount);
+        expect(result).to.equal(expectedUsdc);
+      });
+
+      it("Should handle large amounts correctly", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // 1,000,000 USDC
+        const usdcAmount = 1_000_000n * 10n ** 6n;
+        const expectedJusdEquivalent = ethers.parseEther("1000000");
+        const expectedSvJusd = await svJusd.convertToShares(expectedJusdEquivalent);
+
+        const result = await gateway.bridgedToSvJusd(await usdc.getAddress(), usdcAmount);
+        expect(result).to.equal(expectedSvJusd);
+      });
+
+      it("Should handle small amounts with precision loss", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Very small amount: 1 wei of svJUSD converted to USDC
+        // This tests that precision loss is handled (rounds down to 0)
+        const svJusdAmount = 1n; // 1 wei
+        const result = await gateway.svJusdToBridged(await usdc.getAddress(), svJusdAmount);
+        // 1 wei JUSD = 0 USDC (too small)
+        expect(result).to.equal(0n);
+      });
+    });
+
+    describe("Multiple Bridged Tokens", function () {
+      it("Should support swapping between different bridged tokens via pool", async function () {
+        const { gateway, user1, usdc, usdt, svJusd, swapRouter, usdtBridge } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = 1000n * 10n ** 6n; // 1000 USDC
+
+        // Mock: USDC → svJUSD → USDT path
+        // Router returns svJUSD, then gateway converts to USDT
+        const svJusdOutput = ethers.parseEther("1000");
+        await swapRouter.setSwapOutput(svJusdOutput);
+        await usdtBridge.setMinted(svJusdOutput);
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        const usdtBefore = await usdt.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await usdt.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const usdtAfter = await usdt.balanceOf(user1.address);
+        expect(usdtAfter - usdtBefore).to.equal(1000n * 10n ** 6n);
+      });
+
+      it("Should handle all three bridged tokens independently", async function () {
+        const { gateway, usdc, usdt, ctUsd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // All three should be recognized as bridged tokens
+        expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.true;
+        expect(await gateway.isBridgedToken(await usdt.getAddress())).to.be.true;
+        expect(await gateway.isBridgedToken(await ctUsd.getAddress())).to.be.true;
+
+        // Each should have correct bridge config
+        const tokens = await gateway.getBridgedTokens();
+        expect(tokens.length).to.equal(3);
+      });
     });
   });
 });


### PR DESCRIPTION
## Motivation

Das JuiceSwap Gateway abstrahiert Token-Konvertierungen, sodass User immer mit den Tokens arbeiten können, die sie kennen (JUSD, cBTC), während im Hintergrund optimierte Pools verwendet werden (svJUSD, WcBTC).

**Problem:** Aktuell können User nur mit JUSD oder nativem cBTC Liquidity bereitstellen. Viele User haben aber **USDC.e, USDT.e oder ctUSD** und müssten diese erst manuell über die StablecoinBridge in JUSD konvertieren.

**Lösung:** Das Gateway übernimmt diese Konvertierung automatisch für **alle unterstützten Bridged Stablecoins**. User können direkt mit USDC.e, USDT.e oder ctUSD arbeiten - das Gateway routet intern über die jeweilige StablecoinBridge.

## Unterstützte Bridged Tokens

| Token | Bridge | Decimals |
|-------|--------|----------|
| USDC.e | LayerZero USDC Bridge | 6 |
| USDT.e | LayerZero USDT Bridge | 6 |
| ctUSD | M^0 Protocol Bridge | 6/18 |

## Anwendungsfälle

### 1. Liquidity mit USDC.e bereitstellen
```
User hat: 1000 USDC.e + 0.01 cBTC
User ruft auf: gateway.addLiquidity(USDC_E, cBTC, ...)

Intern passiert:
  USDC.e → Bridge.mint() → JUSD → svJUSD
  cBTC → WcBTC
  → Pool: svJUSD/WcBTC Position wird erstellt
```

### 2. Swap von USDT.e zu anderen Tokens
```
User hat: 500 USDT.e
User ruft auf: gateway.swapExactTokensForTokens(USDT_E, WETH, ...)

Intern passiert:
  USDT.e → Bridge.mint() → JUSD → svJUSD
  svJUSD → Pool → WETH
  → User erhält WETH
```

### 3. Swap zu ctUSD
```
User hat: 1 WETH
User ruft auf: gateway.swapExactTokensForTokens(WETH, CT_USD, ...)

Intern passiert:
  WETH → Pool → svJUSD
  svJUSD → SV_JUSD.redeem() → JUSD
  JUSD → Bridge.burnAndSend() → ctUSD
  → User erhält ctUSD
```

## Vorteile

| Ohne dieses Feature | Mit diesem Feature |
|---------------------|-------------------|
| User muss Bridged Token → JUSD manuell konvertieren | Gateway macht das automatisch |
| 2 Transaktionen nötig (Bridge + addLiquidity) | 1 Transaktion reicht |
| User muss Bridge-Interface kennen | User arbeitet nur mit Gateway |
| Höhere Gas-Kosten durch separate TXs | Optimierte Gas-Kosten |
| Nur ein Bridged Token unterstützt | **Beliebig viele Bridged Tokens** |

## Technische Änderungen

### Neue Dateien
- `contracts/interfaces/IStablecoinBridge.sol` - Interface für die StablecoinBridge
- `contracts/mocks/MockStablecoinBridge.sol` - Mock für Tests

### Gateway Architektur (Mapping-basiert)

**Neue State Variables:**
```solidity
struct BridgeConfig {
    IStablecoinBridge bridge;
    uint8 decimals;
}
mapping(address => BridgeConfig) public bridgeConfigs;
address[] public bridgedTokens;
uint8 public constant MAX_BRIDGED_TOKENS = 10;
uint8 public immutable JUSD_DECIMALS;
```

**Constructor:** Vereinfacht (Bridged Tokens werden post-deployment hinzugefügt)
```solidity
constructor(
    address _jusd,
    address _svJusd,
    address _juice,
    address _wcbtc,
    address _swapRouter,
    address _positionManager
)
```

**Admin Functions:**
```solidity
// Bridged Token hinzufügen
function addBridgedToken(address token, address bridge) external onlyOwner;

// Bridged Token entfernen  
function removeBridgedToken(address token) external onlyOwner;

// Alle Bridged Tokens auflisten
function getBridgedTokens() external view returns (address[] memory);
```

**Token Handling:**
- `_handleTokenIn`: Bridged Token → Bridge.mint() → JUSD → svJUSD
- `_handleTokenOut`: svJUSD → JUSD → Bridge.burnAndSend() → Bridged Token
- `_getActualToken`: Alle Bridged Tokens mappen zu svJUSD

**Decimal Handling (mit dokumentiertem Rounding-Verhalten):**
- `_bridgedToJusdAmount(amount, decimals)`: Bridged decimals → 18 decimals (lossless für 6-decimal tokens)
- `_jusdToBridgedAmount(amount, decimals)`: 18 decimals → Bridged decimals (floor division, favors protocol)
- `_bridgedToSvJusdAmount(amount, decimals)`: Bridged → svJUSD shares (two-step conversion)

**Neue Errors:**
```solidity
error InvalidTokenPair(address tokenA, address tokenB);
error BridgedTokenAlreadyExists(address token);
error BridgedTokenNotFound(address token);
error InvalidBridgeConfig();
error TooManyBridgedTokens();
```

**View Functions:**
```solidity
function bridgedToSvJusd(address bridgedToken, uint256 amount) external view returns (uint256);
function svJusdToBridged(address bridgedToken, uint256 svJusdAmount) external view returns (uint256);
function isBridgedToken(address token) external view returns (bool);
function getBridgedTokens() external view returns (address[] memory);
function getBridgeStatus(address bridgedToken) external view returns (BridgeStatus memory);
```

### Bridge Health Monitoring (NEU)

Das Gateway bietet eine `getBridgeStatus()` Funktion für Frontend-Integration:

```solidity
struct BridgeStatus {
    bool canMint;           // Kann einzahlen (bridged → JUSD)?
    bool canBurn;           // Kann auszahlen (JUSD → bridged)?
    uint256 mintCapacity;   // Verbleibende Mint-Kapazität (JUSD decimals)
    uint256 burnCapacity;   // Verfügbare USD in Bridge (bridged decimals)
    string mintBlockReason; // "Bridge stopped" / "Bridge expired" / "Limit reached"
    string burnBlockReason; // "Insufficient bridge liquidity"
}
```

**Frontend-Beispiel:**
```typescript
const status = await gateway.getBridgeStatus(USDT_ADDRESS);

if (!status.canMint) {
  showError(`Einzahlung nicht möglich: ${status.mintBlockReason}`);
}

if (!status.canBurn) {
  showWarning(`Auszahlung zu USDT nicht möglich. Alternative: JUSD`);
}

// Max deposit anzeigen
const maxDeposit = formatUnits(status.mintCapacity, 18);
```

## Deployment Hinweise

```typescript
// 1. Deploy Gateway (ohne Bridged Tokens)
const gateway = await JuiceSwapGateway.deploy(
    jusd.address,
    svJusd.address,
    juice.address,
    wcbtc.address,
    swapRouter.address,
    positionManager.address
);

// 2. Bridged Tokens hinzufügen
await gateway.addBridgedToken(USDC_E, USDC_E_BRIDGE);
await gateway.addBridgedToken(USDT_E, USDT_E_BRIDGE);
await gateway.addBridgedToken(CT_USD, CT_USD_BRIDGE);
```

## Einschränkungen

1. **Bridge Limits:** Jede StablecoinBridge hat ein `limit` und einen `horizon`. Wenn das Limit erreicht ist oder die Bridge abgelaufen ist, schlagen Operationen mit diesem Token fehl. **Nutze `getBridgeStatus()` um den Status vorab zu prüfen.**

2. **Keine Bridged + JUSD Paare:** Da beide zu svJUSD konvertieren, macht ein Pool keinen Sinn. Der Contract revertiert mit `InvalidTokenPair`.

3. **Keine Bridged + Bridged Paare:** Gleiches Problem - beide würden zu svJUSD konvertieren.

4. **Max 10 Bridged Tokens:** `MAX_BRIDGED_TOKENS = 10` verhindert unbegrenztes Array-Wachstum.

## Rounding-Verhalten

Bei Decimal-Konvertierungen (z.B. 6 → 18 oder 18 → 6) gilt:

| Richtung | Operation | Rounding | Begründung |
|----------|-----------|----------|------------|
| Einzahlung (6→18) | Multiplikation | Lossless | Keine Präzisionsverluste |
| Auszahlung (18→6) | Division | Floor (abrunden) | Favors protocol (DeFi-Standard) |

**Max. Präzisionsverlust bei Auszahlung:** `999999999999 wei ≈ 0.000001 JUSD` pro Transaktion.

## Test Plan

- [x] Unit tests für Bridged Token input conversion (`_handleTokenIn`)
- [x] Unit tests für Bridged Token output conversion (`_handleTokenOut`)
- [x] Unit tests für decimal conversion (6 ↔ 18)
- [x] Test `addBridgedToken` / `removeBridgedToken` admin functions
- [x] Integration test: `addLiquidity(USDC_E, WcBTC, ...)`
- [x] Integration test: `swapExactTokensForTokens(USDT_E, WETH, ...)`
- [x] Integration test: `swapExactTokensForTokens(WETH, CT_USD, ...)`
- [x] Test `InvalidTokenPair` revert für Bridged + JUSD
- [x] Test `_returnExcess` gibt überschüssiges Bridged Token korrekt zurück
- [x] Test mit mehreren Bridged Tokens gleichzeitig
- [x] Test Bridge limit/horizon edge cases
- [x] Test `TooManyBridgedTokens` limit

**26 neue Tests, alle bestanden ✅**