### PR TITLE
feat(gateway): add bridged stablecoin (USDT) support (#21)

### DIFF
--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.20;
 
 import {IJuiceSwapGateway} from "./interfaces/IJuiceSwapGateway.sol";
+import {IStablecoinBridge} from "./interfaces/IStablecoinBridge.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
@@ -149,6 +151,21 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     INonfungiblePositionManager public immutable POSITION_MANAGER;
     IUniswapV3Factory public immutable FACTORY;
 
+    /// @notice Configuration for a bridged stablecoin
+    struct BridgeConfig {
+        IStablecoinBridge bridge;
+        uint8 decimals;
+    }
+
+    /// @notice Mapping of bridged stablecoin address to its bridge configuration
+    mapping(address => BridgeConfig) public bridgeConfigs;
+    /// @notice List of all supported bridged tokens (for enumeration)
+    address[] public bridgedTokens;
+    /// @notice Maximum number of bridged tokens that can be added
+    uint8 public constant MAX_BRIDGED_TOKENS = 10;
+    /// @notice Decimals of JUSD (cached for gas efficiency)
+    uint8 public immutable JUSD_DECIMALS;
+
     address private constant NATIVE_TOKEN = address(0);
     uint24 public defaultFee = 3000; // 0.3% default fee tier
 
@@ -164,10 +181,17 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     error InvalidFee(uint24 fee);
     error TokenMismatch(address expected0, address expected1, address provided0, address provided1);
     error InsufficientLiquidity(uint128 requested, uint128 available);
+    error InvalidTokenPair(address tokenA, address tokenB);
+    error BridgedTokenAlreadyExists(address token);
+    error BridgedTokenNotFound(address token);
+    error InvalidBridgeConfig();
+    error TooManyBridgedTokens();
 
     event TokenRescued(address indexed token, address indexed to, uint256 amount);
     event NativeRescued(address indexed to, uint256 amount);
     event DefaultFeeUpdated(uint24 oldFee, uint24 newFee);
+    event BridgedTokenAdded(address indexed token, address indexed bridge, uint8 decimals);
+    event BridgedTokenRemoved(address indexed token);
 
     /**
      * @notice Initializes the JuiceSwap Gateway for Uniswap V3
@@ -193,6 +217,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         SWAP_ROUTER = ISwapRouter(_swapRouter);
         POSITION_MANAGER = INonfungiblePositionManager(_positionManager);
         FACTORY = IUniswapV3Factory(INonfungiblePositionManager(_positionManager).factory());
+        JUSD_DECIMALS = IERC20Metadata(_jusd).decimals();
 
         // Pre-approve tokens for efficiency
         JUSD.approve(address(SV_JUSD), type(uint256).max);
@@ -268,6 +293,12 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     ) external payable nonReentrant whenNotPaused returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
         if (block.timestamp > deadline) revert DeadlineExpired();
 
+        // Prevent invalid token pairs where both tokens convert to the same actual token
+        // e.g., USDT + JUSD would both become svJUSD
+        if (_getActualToken(tokenA) == _getActualToken(tokenB)) {
+            revert InvalidTokenPair(tokenA, tokenB);
+        }
+
         // Use defaultFee when fee is 0 (JUICE1-6 fix)
         uint24 effectiveFee = fee == 0 ? defaultFee : fee;
 
@@ -285,8 +316,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
                 : (actualTokenB, actualTokenA, actualAmountBDesired, actualAmountADesired);
 
         // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = tokenA == address(JUSD) ? _jusdToSvJusdAmount(amountAMin) : amountAMin;
-        uint256 actualAmountBMin = tokenB == address(JUSD) ? _jusdToSvJusdAmount(amountBMin) : amountBMin;
+        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
 
         (uint256 amount0Min, uint256 amount1Min) =
             isAToken0
@@ -364,13 +395,13 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Transfer NFT to this contract (only after validation passes)
         IERC721(address(POSITION_MANAGER)).transferFrom(msg.sender, address(this), tokenId);
 
-        // Convert input tokens (JUSD → svJUSD)
+        // Convert input tokens (JUSD/bridged USD → svJUSD)
         (address actualTokenA, uint256 actualAmountADesired) = _handleTokenIn(tokenA, amountADesired);
         (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenIn(tokenB, amountBDesired);
 
         // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = tokenA == address(JUSD) ? _jusdToSvJusdAmount(amountAMin) : amountAMin;
-        uint256 actualAmountBMin = tokenB == address(JUSD) ? _jusdToSvJusdAmount(amountBMin) : amountBMin;
+        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
 
         // Cache token ordering comparison
         bool isAToken0 = actualTokenA < actualTokenB;
@@ -408,9 +439,9 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         _returnExcess(tokenB, actualTokenB, excessB, msg.sender);
 
         // Convert amounts back to user-facing token units for return values and event
-        // (amountA/amountB are currently in svJUSD terms if user passed JUSD)
-        uint256 userAmountA = tokenA == address(JUSD) ? _svJusdToJusdAmount(amountA) : amountA;
-        uint256 userAmountB = tokenB == address(JUSD) ? _svJusdToJusdAmount(amountB) : amountB;
+        // (amountA/amountB are currently in svJUSD terms if user passed JUSD or bridged USD)
+        uint256 userAmountA = _toUserAmount(tokenA, amountA);
+        uint256 userAmountB = _toUserAmount(tokenB, amountB);
 
         // Return NFT to user
         IERC721(address(POSITION_MANAGER)).safeTransferFrom(address(this), msg.sender, tokenId);
@@ -458,8 +489,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         address actualTokenB = _getActualToken(tokenB);
 
         // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = tokenA == address(JUSD) ? _jusdToSvJusdAmount(amountAMin) : amountAMin;
-        uint256 actualAmountBMin = tokenB == address(JUSD) ? _jusdToSvJusdAmount(amountBMin) : amountBMin;
+        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
 
         // Determine token order
         bool isAToken0 = actualTokenA < actualTokenB;
@@ -526,6 +557,93 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         return JUICE.calculateShares(jusdAmount);
     }
 
+    function bridgedToSvJusd(address bridgedToken, uint256 amount) external view returns (uint256) {
+        BridgeConfig storage config = bridgeConfigs[bridgedToken];
+        if (address(config.bridge) == address(0)) revert BridgedTokenNotFound(bridgedToken);
+        uint256 jusdAmount = _bridgedToJusdAmount(amount, config.decimals);
+        return SV_JUSD.convertToShares(jusdAmount);
+    }
+
+    function svJusdToBridged(address bridgedToken, uint256 svJusdAmount) external view returns (uint256) {
+        BridgeConfig storage config = bridgeConfigs[bridgedToken];
+        if (address(config.bridge) == address(0)) revert BridgedTokenNotFound(bridgedToken);
+        uint256 jusdAmount = SV_JUSD.convertToAssets(svJusdAmount);
+        return _jusdToBridgedAmount(jusdAmount, config.decimals);
+    }
+
+    function isBridgedToken(address token) external view returns (bool) {
+        return address(bridgeConfigs[token].bridge) != address(0);
+    }
+
+    /**
+     * @notice Returns comprehensive status information for a bridged token's bridge
+     * @dev Useful for frontends to check if operations will succeed before attempting them
+     * @param bridgedToken The bridged stablecoin address to check
+     * @return status The bridge status containing mint/burn capacity and block reasons
+     */
+    function getBridgeStatus(address bridgedToken) external view returns (BridgeStatus memory status) {
+        BridgeConfig storage config = bridgeConfigs[bridgedToken];
+
+        // Check if token is supported
+        if (address(config.bridge) == address(0)) {
+            return BridgeStatus({
+                canMint: false,
+                canBurn: false,
+                mintCapacity: 0,
+                burnCapacity: 0,
+                mintBlockReason: "Token not supported",
+                burnBlockReason: "Token not supported"
+            });
+        }
+
+        IStablecoinBridge bridge = config.bridge;
+
+        // === MINT CHECKS (bridged token → JUSD) ===
+        bool canMint = true;
+        string memory mintReason = "";
+        uint256 mintCapacity = 0;
+
+        // Check if bridge is stopped
+        if (bridge.stopped()) {
+            canMint = false;
+            mintReason = "Bridge stopped";
+        }
+        // Check if bridge is expired
+        else if (block.timestamp > bridge.horizon()) {
+            canMint = false;
+            mintReason = "Bridge expired";
+        }
+        // Check mint limit
+        else {
+            uint256 minted = bridge.minted();
+            uint256 limit = bridge.limit();
+            if (minted >= limit) {
+                canMint = false;
+                mintReason = "Limit reached";
+            } else {
+                // Remaining capacity in JUSD (18 decimals)
+                mintCapacity = limit - minted;
+            }
+        }
+
+        // === BURN CHECKS (JUSD → bridged token) ===
+        // Burn needs the bridge to have sufficient bridged token balance
+        address usdToken = bridge.usd();
+        uint256 bridgeBalance = IERC20(usdToken).balanceOf(address(bridge));
+
+        bool canBurn = bridgeBalance > 0;
+        string memory burnReason = canBurn ? "" : "Insufficient bridge liquidity";
+
+        return BridgeStatus({
+            canMint: canMint,
+            canBurn: canBurn,
+            mintCapacity: mintCapacity,
+            burnCapacity: bridgeBalance,  // In bridged token decimals
+            mintBlockReason: mintReason,
+            burnBlockReason: burnReason
+        });
+    }
+
     // ==================== Internal Functions ====================
 
     /**
@@ -546,9 +664,23 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             // JUICE cannot be used as input due to Equity flash loan protection.
             // Users must redeem JUICE directly: JUICE.redeem() → then swap the JUSD.
             revert JuiceInputNotSupported();
+        }
+
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[token];
+        if (address(config.bridge) != address(0)) {
+            // Bridged USD (e.g., USDC.e, USDT.e, ctUSD) → JUSD (via Bridge) → svJUSD
+            SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), amount);
+            // Bridge mints JUSD (handles decimal conversion internally)
+            config.bridge.mint(amount);
+            // Convert bridged USD amount to JUSD amount (e.g., 6 decimals → 18 decimals)
+            uint256 jusdAmount = _bridgedToJusdAmount(amount, config.decimals);
+            // Deposit JUSD into savings vault
+            uint256 shares = SV_JUSD.deposit(jusdAmount, address(this));
+            return (address(SV_JUSD), shares);
         } else {
             // Other tokens - direct transfer
-            IERC20(token).transferFrom(msg.sender, address(this), amount);
+            SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), amount);
             if (IERC20(token).allowance(address(this), address(SWAP_ROUTER)) < amount) {
                 SafeERC20.forceApprove(IERC20(token), address(SWAP_ROUTER), type(uint256).max);
             }
@@ -577,11 +709,22 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             // svJUSD → JUSD → JUICE
             uint256 jusdAmount = SV_JUSD.redeem(actualAmount, address(this), address(this));
             uint256 juiceAmount = JUICE.invest(jusdAmount, 0);
-            JUICE.transfer(to, juiceAmount);
+            SafeERC20.safeTransfer(IERC20(address(JUICE)), to, juiceAmount);
             return juiceAmount;
+        }
+
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[token];
+        if (address(config.bridge) != address(0)) {
+            // svJUSD → JUSD → Bridged USD (e.g., USDC.e, USDT.e, ctUSD)
+            uint256 jusdAmount = SV_JUSD.redeem(actualAmount, address(this), address(this));
+            // Burn JUSD via bridge to get bridged USD sent to recipient
+            config.bridge.burnAndSend(to, jusdAmount);
+            // Return amount in bridged USD decimals
+            return _jusdToBridgedAmount(jusdAmount, config.decimals);
         } else {
             // Other tokens - direct transfer
-            IERC20(token).transfer(to, actualAmount);
+            SafeERC20.safeTransfer(IERC20(token), to, actualAmount);
             return actualAmount;
         }
     }
@@ -593,6 +736,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         if (token == NATIVE_TOKEN) return address(WCBTC);
         if (token == address(JUSD)) return address(SV_JUSD);
         if (token == address(JUICE)) return address(SV_JUSD); // JUICE swaps through equity
+        // Check if token is a bridged stablecoin
+        if (address(bridgeConfigs[token].bridge) != address(0)) return address(SV_JUSD);
         return token;
     }
 
@@ -608,6 +753,92 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      */
     function _svJusdToJusdAmount(uint256 svJusdAmount) internal view returns (uint256) {
         return SV_JUSD.convertToAssets(svJusdAmount);
+    }
+
+    /**
+     * @dev Converts bridged token amount to JUSD amount (e.g., 6 decimals → 18 decimals)
+     * @notice For tokens with fewer decimals than JUSD (e.g., USDC/USDT with 6 decimals),
+     *         this is a lossless multiplication. For tokens with more decimals than JUSD
+     *         (rare edge case), this rounds DOWN which favors the protocol on deposits.
+     * @param bridgedAmount The amount in bridged token decimals
+     * @param bridgedDecimals The decimal count of the bridged token
+     * @return The equivalent amount in JUSD decimals (18)
+     */
+    function _bridgedToJusdAmount(uint256 bridgedAmount, uint8 bridgedDecimals) internal view returns (uint256) {
+        if (bridgedDecimals < JUSD_DECIMALS) {
+            // Scale up: lossless (e.g., 1_000000 USDC → 1_000000000000000000 JUSD)
+            return bridgedAmount * 10 ** (JUSD_DECIMALS - bridgedDecimals);
+        } else if (bridgedDecimals > JUSD_DECIMALS) {
+            // Scale down: intentional floor division (rare case, favors protocol)
+            return bridgedAmount / 10 ** (bridgedDecimals - JUSD_DECIMALS);
+        }
+        return bridgedAmount;
+    }
+
+    /**
+     * @dev Converts JUSD amount to bridged token amount (e.g., 18 decimals → 6 decimals)
+     * @notice Rounds DOWN (floor) intentionally to favor the protocol on withdrawals.
+     *         This is standard DeFi practice: users receive slightly less on outbound transfers.
+     *         Maximum precision loss per conversion: 10^(JUSD_DECIMALS - bridgedDecimals) - 1 wei
+     *         Example for 6-decimal tokens: max loss is 999999999999 wei ≈ 0.000000999999 JUSD
+     * @param jusdAmount The amount in JUSD decimals (18)
+     * @param bridgedDecimals The decimal count of the bridged token
+     * @return The equivalent amount in bridged token decimals (rounded down)
+     */
+    function _jusdToBridgedAmount(uint256 jusdAmount, uint8 bridgedDecimals) internal view returns (uint256) {
+        if (JUSD_DECIMALS > bridgedDecimals) {
+            // Scale down: intentional floor division (favors protocol on withdrawals)
+            return jusdAmount / 10 ** (JUSD_DECIMALS - bridgedDecimals);
+        } else if (JUSD_DECIMALS < bridgedDecimals) {
+            // Scale up: lossless (rare case)
+            return jusdAmount * 10 ** (bridgedDecimals - JUSD_DECIMALS);
+        }
+        return jusdAmount;
+    }
+
+    /**
+     * @dev Converts bridged token amount to svJUSD shares
+     * @notice Two-step conversion: bridged → JUSD (lossless for 6-decimal tokens) → svJUSD shares.
+     *         The svJUSD conversion uses ERC4626 convertToShares which may introduce
+     *         additional rounding based on the vault's share price.
+     * @param bridgedAmount The amount in bridged token decimals
+     * @param bridgedDecimals The decimal count of the bridged token
+     * @return The equivalent amount in svJUSD shares
+     */
+    function _bridgedToSvJusdAmount(uint256 bridgedAmount, uint8 bridgedDecimals) internal view returns (uint256) {
+        uint256 jusdAmount = _bridgedToJusdAmount(bridgedAmount, bridgedDecimals);
+        return SV_JUSD.convertToShares(jusdAmount);
+    }
+
+    /**
+     * @dev Converts user-facing min amount to actual token min amount
+     */
+    function _toActualMinAmount(address userToken, uint256 minAmount) internal view returns (uint256) {
+        if (userToken == address(JUSD)) {
+            return _jusdToSvJusdAmount(minAmount);
+        }
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[userToken];
+        if (address(config.bridge) != address(0)) {
+            return _bridgedToSvJusdAmount(minAmount, config.decimals);
+        }
+        return minAmount;
+    }
+
+    /**
+     * @dev Converts actual token amount back to user-facing token amount
+     */
+    function _toUserAmount(address userToken, uint256 actualAmount) internal view returns (uint256) {
+        if (userToken == address(JUSD)) {
+            return _svJusdToJusdAmount(actualAmount);
+        }
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[userToken];
+        if (address(config.bridge) != address(0)) {
+            uint256 jusdAmount = _svJusdToJusdAmount(actualAmount);
+            return _jusdToBridgedAmount(jusdAmount, config.decimals);
+        }
+        return actualAmount;
     }
 
     /**
@@ -640,9 +871,22 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             WCBTC.withdraw(excessAmount);
             (bool success, ) = to.call{value: excessAmount}("");
             if (!success) revert TransferFailed();
+        } else if (actualToken == address(SV_JUSD)) {
+            // Check if userToken is a bridged stablecoin
+            BridgeConfig storage config = bridgeConfigs[userToken];
+            if (address(config.bridge) != address(0)) {
+                // Convert excess svJUSD back to bridged USD via JUSD
+                uint256 jusdAmount = SV_JUSD.redeem(excessAmount, address(this), address(this));
+                config.bridge.burnAndSend(to, jusdAmount);
+            } else {
+                // Unreachable: if actualToken is svJUSD, userToken must be JUSD (handled above)
+                // or a bridged token (handled in if-branch). JUICE maps to svJUSD but cannot
+                // be used as input (JuiceInputNotSupported), so this branch is never reached.
+                revert InvalidToken();
+            }
         } else if (actualToken != address(0)) {
             // Return excess tokens directly
-            IERC20(actualToken).transfer(to, excessAmount);
+            SafeERC20.safeTransfer(IERC20(actualToken), to, excessAmount);
         }
     }
 
@@ -664,6 +908,76 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     }
 
     /**
+     * @notice Adds a bridged stablecoin that can be converted to JUSD via its bridge
+     * @param token The bridged stablecoin address (e.g., USDC.e, USDT.e, ctUSD)
+     * @param bridge The StablecoinBridge contract for this token
+     */
+    function addBridgedToken(address token, address bridge) external onlyOwner {
+        if (token == address(0) || bridge == address(0)) revert InvalidBridgeConfig();
+        if (bridgedTokens.length >= MAX_BRIDGED_TOKENS) revert TooManyBridgedTokens();
+        if (bridgeConfigs[token].bridge != IStablecoinBridge(address(0))) {
+            revert BridgedTokenAlreadyExists(token);
+        }
+
+        // Validate bridge configuration matches expected tokens
+        IStablecoinBridge bridgeContract = IStablecoinBridge(bridge);
+        if (bridgeContract.usd() != token) revert InvalidBridgeConfig();
+        if (bridgeContract.JUSD() != address(JUSD)) revert InvalidBridgeConfig();
+
+        uint8 decimals = IERC20Metadata(token).decimals();
+        bridgeConfigs[token] = BridgeConfig({
+            bridge: IStablecoinBridge(bridge),
+            decimals: decimals
+        });
+        bridgedTokens.push(token);
+
+        // Approve bridged token to bridge for mint operations
+        IERC20(token).approve(bridge, type(uint256).max);
+        // Approve JUSD to bridge for burn operations
+        JUSD.approve(bridge, type(uint256).max);
+
+        emit BridgedTokenAdded(token, bridge, decimals);
+    }
+
+    /**
+     * @notice Removes a bridged stablecoin from the supported list
+     * @param token The bridged stablecoin address to remove
+     */
+    function removeBridgedToken(address token) external onlyOwner {
+        if (bridgeConfigs[token].bridge == IStablecoinBridge(address(0))) {
+            revert BridgedTokenNotFound(token);
+        }
+
+        address bridge = address(bridgeConfigs[token].bridge);
+
+        // Remove from mapping
+        delete bridgeConfigs[token];
+
+        // Remove from array (swap with last element and pop)
+        uint256 length = bridgedTokens.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (bridgedTokens[i] == token) {
+                bridgedTokens[i] = bridgedTokens[length - 1];
+                bridgedTokens.pop();
+                break;
+            }
+        }
+
+        // Revoke approvals
+        IERC20(token).approve(bridge, 0);
+        JUSD.approve(bridge, 0);
+
+        emit BridgedTokenRemoved(token);
+    }
+
+    /**
+     * @notice Returns all supported bridged tokens
+     */
+    function getBridgedTokens() external view returns (address[] memory) {
+        return bridgedTokens;
+    }
+
+    /**
      * @notice Rescue function to withdraw accidentally sent native cBTC
      */
     function rescueNative() external onlyOwner {
@@ -680,7 +994,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
      */
     function rescueToken(address token, address to, uint256 amount) external onlyOwner {
         if (to == address(0)) revert InvalidToken();
-        IERC20(token).transfer(to, amount);
+        SafeERC20.safeTransfer(IERC20(token), to, amount);
         emit TokenRescued(token, to, amount);
     }
 

--- a/contracts/interfaces/IJuiceSwapGateway.sol
+++ b/contracts/interfaces/IJuiceSwapGateway.sol
@@ -8,8 +8,18 @@ pragma solidity ^0.8.20;
  *      - JUSD ↔ svJUSD conversions (for interest-bearing liquidity)
  *      - JUICE ↔ JUSD conversions (via Equity contract)
  *      - cBTC ↔ WcBTC wrapping
+ *      - Bridged stablecoins ↔ JUSD conversions (via StablecoinBridge)
  */
 interface IJuiceSwapGateway {
+    /// @notice Status information for a bridged stablecoin's bridge
+    struct BridgeStatus {
+        bool canMint;           // Can deposit bridged token (mint JUSD)?
+        bool canBurn;           // Can withdraw to bridged token (burn JUSD)?
+        uint256 mintCapacity;   // Remaining JUSD that can be minted (in JUSD decimals)
+        uint256 burnCapacity;   // Available bridged token for burns (in bridged token decimals)
+        string mintBlockReason; // Reason why minting is blocked (empty if canMint)
+        string burnBlockReason; // Reason why burning is blocked (empty if canBurn)
+    }
     /**
      * @notice Emitted when a swap is executed through the gateway
      * @param user The address that initiated the swap
@@ -204,4 +214,61 @@ interface IJuiceSwapGateway {
      * @return juiceAmount The amount of JUICE received
      */
     function jusdToJuice(uint256 jusdAmount) external view returns (uint256 juiceAmount);
+
+    /**
+     * @notice Returns the equivalent amount of svJUSD for a given amount of bridged stablecoin
+     * @param bridgedToken The bridged stablecoin address (e.g., USDC.e, USDT.e, ctUSD)
+     * @param amount The amount of bridged stablecoin (in its native decimals)
+     * @return svJusdAmount The equivalent amount of svJUSD
+     */
+    function bridgedToSvJusd(address bridgedToken, uint256 amount) external view returns (uint256 svJusdAmount);
+
+    /**
+     * @notice Returns the equivalent amount of bridged stablecoin for a given amount of svJUSD
+     * @param bridgedToken The bridged stablecoin address (e.g., USDC.e, USDT.e, ctUSD)
+     * @param svJusdAmount The amount of svJUSD
+     * @return amount The equivalent amount of bridged stablecoin (in its native decimals)
+     */
+    function svJusdToBridged(address bridgedToken, uint256 svJusdAmount) external view returns (uint256 amount);
+
+    /**
+     * @notice Checks if a token is a supported bridged stablecoin
+     * @param token The token address to check
+     * @return True if the token is a supported bridged stablecoin
+     */
+    function isBridgedToken(address token) external view returns (bool);
+
+    /**
+     * @notice Returns all supported bridged tokens
+     * @return Array of bridged token addresses
+     */
+    function getBridgedTokens() external view returns (address[] memory);
+
+    /**
+     * @notice Adds a bridged stablecoin that can be converted to JUSD via its bridge
+     * @param token The bridged stablecoin address
+     * @param bridge The StablecoinBridge contract for this token
+     */
+    function addBridgedToken(address token, address bridge) external;
+
+    /**
+     * @notice Removes a bridged stablecoin from the supported list
+     * @param token The bridged stablecoin address to remove
+     */
+    function removeBridgedToken(address token) external;
+
+    /**
+     * @notice Returns comprehensive status information for a bridged token's bridge
+     * @dev Useful for frontends to check if operations will succeed before attempting them.
+     *      Checks include: bridge stopped, bridge expired, mint limit reached, burn liquidity.
+     * @param bridgedToken The bridged stablecoin address to check
+     * @return status The bridge status containing:
+     *         - canMint: Whether deposits (bridged → JUSD) are possible
+     *         - canBurn: Whether withdrawals (JUSD → bridged) are possible
+     *         - mintCapacity: Remaining JUSD mintable through this bridge
+     *         - burnCapacity: Available bridged tokens in bridge for withdrawals
+     *         - mintBlockReason: Human-readable reason if minting blocked
+     *         - burnBlockReason: Human-readable reason if burning blocked
+     */
+    function getBridgeStatus(address bridgedToken) external view returns (BridgeStatus memory status);
 }

--- a/contracts/interfaces/IStablecoinBridge.sol
+++ b/contracts/interfaces/IStablecoinBridge.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IStablecoinBridge
+ * @notice Interface for the StablecoinBridge contract that enables 1:1 conversion
+ *         between a trusted stablecoin (e.g., USDT) and JUSD.
+ */
+interface IStablecoinBridge {
+    /**
+     * @notice Mint JUSD by depositing source stablecoin (e.g., USDT)
+     * @param amount The amount of source stablecoin to convert
+     */
+    function mint(uint256 amount) external;
+
+    /**
+     * @notice Mint JUSD to a specific address
+     * @param target The address to receive JUSD
+     * @param amount The amount of source stablecoin to convert
+     */
+    function mintTo(address target, uint256 amount) external;
+
+    /**
+     * @notice Burn JUSD and receive source stablecoin
+     * @param amount The amount of JUSD to burn
+     */
+    function burn(uint256 amount) external;
+
+    /**
+     * @notice Burn JUSD and send source stablecoin to a specific address
+     * @param target The address to receive the source stablecoin
+     * @param amount The amount of JUSD to burn
+     */
+    function burnAndSend(address target, uint256 amount) external;
+
+    /**
+     * @notice Check if the bridge has been permanently stopped
+     */
+    function stopped() external view returns (bool);
+
+    /**
+     * @notice The expiration timestamp after which minting is disabled
+     */
+    function horizon() external view returns (uint256);
+
+    /**
+     * @notice The maximum amount of JUSD that can be minted through this bridge
+     */
+    function limit() external view returns (uint256);
+
+    /**
+     * @notice The current amount of JUSD minted through this bridge
+     */
+    function minted() external view returns (uint256);
+
+    /**
+     * @notice The source stablecoin token (e.g., USDT)
+     */
+    function usd() external view returns (address);
+
+    /**
+     * @notice The JUSD token
+     */
+    function JUSD() external view returns (address);
+}

--- a/contracts/mocks/MockStablecoinBridge.sol
+++ b/contracts/mocks/MockStablecoinBridge.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IMockJUSD is IERC20 {
+    function mint(address to, uint256 amount) external;
+    function burn(address from, uint256 amount) external;
+}
+
+/**
+ * @title MockStablecoinBridge
+ * @notice Mock bridge for testing bridged stablecoin conversions
+ * @dev Simulates 1:1 conversion between a bridged stablecoin (e.g., USDT) and JUSD
+ */
+contract MockStablecoinBridge {
+    using SafeERC20 for IERC20;
+
+    IERC20 public immutable usd;
+    IMockJUSD public immutable JUSD;
+    uint8 private immutable usdDecimals;
+    uint8 private immutable jusdDecimals;
+
+    uint256 public immutable horizon;
+    uint256 public immutable limit;
+    uint256 public minted;
+    bool public stopped;
+
+    error Stopped();
+    error Expired();
+    error LimitExceeded();
+
+    constructor(address _usd, address _jusd, uint256 _limit, uint256 _weeks) {
+        usd = IERC20(_usd);
+        JUSD = IMockJUSD(_jusd);
+        usdDecimals = IERC20Metadata(_usd).decimals();
+        jusdDecimals = IERC20Metadata(_jusd).decimals();
+        horizon = block.timestamp + _weeks * 1 weeks;
+        limit = _limit;
+    }
+
+    function mint(uint256 amount) external {
+        mintTo(msg.sender, amount);
+    }
+
+    function mintTo(address target, uint256 amount) public {
+        if (stopped) revert Stopped();
+        if (block.timestamp > horizon) revert Expired();
+
+        usd.safeTransferFrom(msg.sender, address(this), amount);
+
+        uint256 jusdAmount = _convertAmount(amount, usdDecimals, jusdDecimals);
+        minted += jusdAmount;
+        if (minted > limit) revert LimitExceeded();
+
+        JUSD.mint(target, jusdAmount);
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, msg.sender, amount);
+    }
+
+    function burnAndSend(address target, uint256 amount) external {
+        _burn(msg.sender, target, amount);
+    }
+
+    function _burn(address jusdHolder, address target, uint256 amount) internal {
+        uint256 usdAmount = _convertAmount(amount, jusdDecimals, usdDecimals);
+
+        JUSD.burn(jusdHolder, amount);
+        usd.safeTransfer(target, usdAmount);
+        minted -= amount;
+    }
+
+    function _convertAmount(uint256 amount, uint8 fromDecimals, uint8 toDecimals) internal pure returns (uint256) {
+        if (fromDecimals < toDecimals) {
+            return amount * 10 ** (toDecimals - fromDecimals);
+        } else if (fromDecimals > toDecimals) {
+            return amount / 10 ** (fromDecimals - toDecimals);
+        }
+        return amount;
+    }
+
+    // Test helpers
+    function setMinted(uint256 _minted) external {
+        minted = _minted;
+    }
+
+    function setStopped(bool _stopped) external {
+        stopped = _stopped;
+    }
+}

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -9,6 +9,7 @@ import {
   MockWETH,
   MockSwapRouter,
   MockPositionManager,
+  MockStablecoinBridge,
 } from "../typechain-types";
 import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
@@ -2476,6 +2477,807 @@ describe("JuiceSwapGateway", function () {
           anyValue,
           tokenId  // Verify correct tokenId is emitted
         );
+    });
+  });
+
+  describe("Bridged Token Support", function () {
+    const BRIDGE_LIMIT = ethers.parseEther("100000000"); // 100M JUSD
+    const BRIDGE_WEEKS = 208; // 4 years
+
+    /**
+     * Deploy gateway with bridged token support (standalone fixture)
+     */
+    async function deployGatewayWithBridgedTokensFixture() {
+      const [owner, user1, user2, feeCollector] = await ethers.getSigners();
+
+      // Deploy core mocks
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const jusd = (await MockERC20Factory.deploy("JuiceDollar", "JUSD", 18)) as unknown as MockERC20;
+
+      const MockEquityFactory = await ethers.getContractFactory("MockEquity");
+      const juice = (await MockEquityFactory.deploy("Juice Protocol", "JUICE", await jusd.getAddress())) as unknown as MockEquity;
+
+      const MockERC4626Factory = await ethers.getContractFactory("MockERC4626");
+      const svJusd = (await MockERC4626Factory.deploy(await jusd.getAddress(), "Savings Vault JUSD", "svJUSD")) as unknown as MockERC4626;
+
+      const MockWETHFactory = await ethers.getContractFactory("MockWETH");
+      const wcbtc = (await MockWETHFactory.deploy("Wrapped cBTC", "WcBTC")) as unknown as MockWETH;
+
+      const MockSwapRouterFactory = await ethers.getContractFactory("MockSwapRouter");
+      const swapRouter = (await MockSwapRouterFactory.deploy()) as unknown as MockSwapRouter;
+
+      const MockPositionManagerFactory = await ethers.getContractFactory("MockPositionManager");
+      const positionManager = (await MockPositionManagerFactory.deploy()) as unknown as MockPositionManager;
+
+      // Deploy gateway
+      const JuiceSwapGatewayFactory = await ethers.getContractFactory("JuiceSwapGateway");
+      const gateway = (await JuiceSwapGatewayFactory.deploy(
+        await jusd.getAddress(),
+        await svJusd.getAddress(),
+        await juice.getAddress(),
+        await wcbtc.getAddress(),
+        await swapRouter.getAddress(),
+        await positionManager.getAddress()
+      )) as unknown as JuiceSwapGateway;
+
+      // Setup balances
+      await jusd.mint(user1.address, INITIAL_BALANCE);
+      await jusd.mint(user2.address, INITIAL_BALANCE);
+      await juice.mint(user1.address, INITIAL_BALANCE);
+      await wcbtc.connect(user1).deposit({ value: ethers.parseEther("100") });
+      await wcbtc.connect(user2).deposit({ value: ethers.parseEther("100") });
+      await jusd.mint(await svJusd.getAddress(), ethers.parseEther("100000"));
+      await jusd.mint(await juice.getAddress(), ethers.parseEther("10000"));
+
+      // Deploy bridged stablecoins (6 decimals like USDT/USDC)
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC.e", 6)) as unknown as MockERC20;
+      const usdt = (await MockERC20Factory.deploy("Tether USD", "USDT.e", 6)) as unknown as MockERC20;
+      const ctUsd = (await MockERC20Factory.deploy("M0 USD", "ctUSD", 6)) as unknown as MockERC20;
+
+      // Deploy bridges
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = (await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        BRIDGE_LIMIT,
+        BRIDGE_WEEKS
+      )) as unknown as MockStablecoinBridge;
+      const usdtBridge = (await MockBridgeFactory.deploy(
+        await usdt.getAddress(),
+        await jusd.getAddress(),
+        BRIDGE_LIMIT,
+        BRIDGE_WEEKS
+      )) as unknown as MockStablecoinBridge;
+      const ctUsdBridge = (await MockBridgeFactory.deploy(
+        await ctUsd.getAddress(),
+        await jusd.getAddress(),
+        BRIDGE_LIMIT,
+        BRIDGE_WEEKS
+      )) as unknown as MockStablecoinBridge;
+
+      // Fund bridges with bridged tokens (for burn operations)
+      const bridgeAmount = 10_000_000n * 10n ** 6n; // 10M with 6 decimals
+      await usdc.mint(await usdcBridge.getAddress(), bridgeAmount);
+      await usdt.mint(await usdtBridge.getAddress(), bridgeAmount);
+      await ctUsd.mint(await ctUsdBridge.getAddress(), bridgeAmount);
+
+      // Mint bridged tokens to users
+      const userAmount = 100_000n * 10n ** 6n; // 100k with 6 decimals
+      await usdc.mint(user1.address, userAmount);
+      await usdt.mint(user1.address, userAmount);
+      await ctUsd.mint(user1.address, userAmount);
+
+      // Add bridged tokens to gateway
+      await gateway.connect(owner).addBridgedToken(await usdc.getAddress(), await usdcBridge.getAddress());
+      await gateway.connect(owner).addBridgedToken(await usdt.getAddress(), await usdtBridge.getAddress());
+      await gateway.connect(owner).addBridgedToken(await ctUsd.getAddress(), await ctUsdBridge.getAddress());
+
+      return {
+        owner,
+        user1,
+        user2,
+        feeCollector,
+        jusd,
+        juice,
+        svJusd,
+        wcbtc,
+        swapRouter,
+        positionManager,
+        gateway,
+        usdc,
+        usdt,
+        ctUsd,
+        usdcBridge,
+        usdtBridge,
+        ctUsdBridge,
+      };
+    }
+
+    describe("Admin Functions", function () {
+      it("Should add bridged token", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await newToken.getAddress(),
+            await newBridge.getAddress()
+          )
+        ).to.emit(gateway, "BridgedTokenAdded")
+          .withArgs(await newToken.getAddress(), await newBridge.getAddress(), 6);
+
+        expect(await gateway.isBridgedToken(await newToken.getAddress())).to.be.true;
+      });
+
+      it("Should revert when adding duplicate bridged token", async function () {
+        const { gateway, owner, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await usdc.getAddress(),
+            await usdcBridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenAlreadyExists");
+      });
+
+      it("Should revert when non-owner adds bridged token", async function () {
+        const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(user1).addBridgedToken(
+            await newToken.getAddress(),
+            await newBridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "OwnableUnauthorizedAccount");
+      });
+
+      it("Should remove bridged token", async function () {
+        const { gateway, owner, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.connect(owner).removeBridgedToken(await usdc.getAddress())
+        ).to.emit(gateway, "BridgedTokenRemoved")
+          .withArgs(await usdc.getAddress());
+
+        expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.false;
+      });
+
+      it("Should revoke both token and JUSD approvals when removing bridged token", async function () {
+        const { gateway, owner, usdc, usdt, usdcBridge, usdtBridge, jusd } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const gatewayAddress = await gateway.getAddress();
+        const usdcBridgeAddress = await usdcBridge.getAddress();
+        const usdtBridgeAddress = await usdtBridge.getAddress();
+
+        // Verify both bridges have unlimited JUSD approval before removal
+        expect(await jusd.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(ethers.MaxUint256);
+        expect(await jusd.allowance(gatewayAddress, usdtBridgeAddress)).to.equal(ethers.MaxUint256);
+
+        // Remove USDC bridge
+        await gateway.connect(owner).removeBridgedToken(await usdc.getAddress());
+
+        // Verify USDC bridge approvals are revoked
+        expect(await usdc.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(0);
+        expect(await jusd.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(0);
+
+        // Verify USDT bridge approvals remain unaffected
+        expect(await jusd.allowance(gatewayAddress, usdtBridgeAddress)).to.equal(ethers.MaxUint256);
+      });
+
+      it("Should revert when removing non-existent bridged token", async function () {
+        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const randomAddress = ethers.Wallet.createRandom().address;
+        await expect(
+          gateway.connect(owner).removeBridgedToken(randomAddress)
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+      });
+
+      it("Should return all bridged tokens", async function () {
+        const { gateway, usdc, usdt, ctUsd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const tokens = await gateway.getBridgedTokens();
+        expect(tokens.length).to.equal(3);
+        expect(tokens).to.include(await usdc.getAddress());
+        expect(tokens).to.include(await usdt.getAddress());
+        expect(tokens).to.include(await ctUsd.getAddress());
+      });
+
+      it("Should revert with InvalidBridgeConfig for zero addresses", async function () {
+        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(ethers.ZeroAddress, ethers.ZeroAddress)
+        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
+      });
+
+      it("Should revert with TooManyBridgedTokens when limit exceeded", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+
+        // Already have 3 tokens, add 7 more to reach limit of 10
+        for (let i = 0; i < 7; i++) {
+          const token = await MockERC20Factory.deploy(`Token${i}`, `TKN${i}`, 6);
+          const bridge = await MockBridgeFactory.deploy(
+            await token.getAddress(),
+            await jusd.getAddress(),
+            BRIDGE_LIMIT,
+            BRIDGE_WEEKS
+          );
+          await gateway.connect(owner).addBridgedToken(
+            await token.getAddress(),
+            await bridge.getAddress()
+          );
+        }
+
+        // 11th token should fail
+        const extraToken = await MockERC20Factory.deploy("Extra", "EXTRA", 6);
+        const extraBridge = await MockBridgeFactory.deploy(
+          await extraToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await extraToken.getAddress(),
+            await extraBridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "TooManyBridgedTokens");
+      });
+
+      it("Should revert with InvalidBridgeConfig when bridge.usd() != token", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+
+        // Deploy a token and a bridge for a DIFFERENT token
+        const wrongToken = await MockERC20Factory.deploy("Wrong", "WRONG", 6);
+        const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+        const bridge = await MockBridgeFactory.deploy(
+          await usdc.getAddress(),  // Bridge expects USDC
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        // Try to add wrongToken with a bridge configured for USDC
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await wrongToken.getAddress(),
+            await bridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
+      });
+
+      it("Should revert with InvalidBridgeConfig when bridge.JUSD() != gateway JUSD", async function () {
+        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+
+        // Deploy a bridge pointing to a different JUSD
+        const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+        const fakeJusd = await MockERC20Factory.deploy("Fake JUSD", "FJUSD", 18);
+        const bridge = await MockBridgeFactory.deploy(
+          await usdc.getAddress(),
+          await fakeJusd.getAddress(),  // Wrong JUSD
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        await expect(
+          gateway.connect(owner).addBridgedToken(
+            await usdc.getAddress(),
+            await bridge.getAddress()
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
+      });
+    });
+
+    describe("Swap with Bridged Tokens", function () {
+      it("Should swap bridged token (USDC.e) to WcBTC", async function () {
+        const { gateway, user1, usdc, wcbtc, swapRouter } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
+        const expectedOutput = ethers.parseEther("0.01"); // 0.01 WcBTC
+
+        await swapRouter.setSwapOutput(expectedOutput);
+        await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        const wcbtcBefore = await wcbtc.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await wcbtc.getAddress(),
+          0, // use default fee
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const wcbtcAfter = await wcbtc.balanceOf(user1.address);
+        expect(wcbtcAfter - wcbtcBefore).to.equal(expectedOutput);
+      });
+
+      it("Should swap WcBTC to bridged token (USDT.e)", async function () {
+        const { gateway, user1, usdt, wcbtc, svJusd, swapRouter, usdtBridge } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("0.01"); // 0.01 WcBTC
+        const svJusdOutput = ethers.parseEther("1000"); // Mock router returns this
+
+        await swapRouter.setSwapOutput(svJusdOutput);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        // Track bridge minted amount for the burn
+        await usdtBridge.setMinted(svJusdOutput);
+
+        const usdtBefore = await usdt.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await wcbtc.getAddress(),
+          await usdt.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const usdtAfter = await usdt.balanceOf(user1.address);
+        // 1000 JUSD (18 decimals) = 1000 USDT (6 decimals)
+        expect(usdtAfter - usdtBefore).to.equal(1000n * 10n ** 6n);
+      });
+
+      it("Should emit SwapExecuted event with bridged token addresses", async function () {
+        const { gateway, user1, usdc, wcbtc, swapRouter } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = 1000n * 10n ** 6n;
+
+        await swapRouter.setSwapOutput(ethers.parseEther("0.01"));
+        await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        await expect(
+          gateway.connect(user1).swapExactTokensForTokens(
+            await usdc.getAddress(),
+            await wcbtc.getAddress(),
+            0,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          )
+        ).to.emit(gateway, "SwapExecuted")
+          .withArgs(user1.address, await usdc.getAddress(), await wcbtc.getAddress(), anyValue, anyValue);
+      });
+    });
+
+    describe("Add Liquidity with Bridged Tokens", function () {
+      it("Should add liquidity with bridged token (USDC.e) + WcBTC", async function () {
+        const { gateway, user1, usdc, wcbtc, svJusd, positionManager } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const usdcAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
+        const wcbtcAmount = ethers.parseEther("0.01");
+
+        // Calculate expected svJUSD shares (1000 USDC = 1000 JUSD = ~1000 svJUSD shares)
+        const jusdEquivalent = ethers.parseEther("1000"); // 1000 USDC = 1000 JUSD
+        const svJusdShares = await svJusd.convertToShares(jusdEquivalent);
+
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const [amount0, amount1] = svJusdAddr < wcbtcAddr
+          ? [svJusdShares, wcbtcAmount]
+          : [wcbtcAmount, svJusdShares];
+
+        await positionManager.setMintResult(1, 100, amount0, amount1);
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+        const tx = await gateway.connect(user1).addLiquidity(
+          await usdc.getAddress(),
+          await wcbtc.getAddress(),
+          0, // default fee
+          usdcAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+        await expect(tx)
+          .to.emit(gateway, "LiquidityAdded")
+          .withArgs(user1.address, await usdc.getAddress(), await wcbtc.getAddress(), anyValue, anyValue, 1);
+      });
+
+      it("Should revert with InvalidTokenPair for bridged token + JUSD", async function () {
+        const { gateway, user1, usdc, jusd } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const amount = 1000n * 10n ** 6n;
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), amount);
+        await jusd.connect(user1).approve(await gateway.getAddress(), ethers.parseEther("1000"));
+
+        await expect(
+          gateway.connect(user1).addLiquidity(
+            await usdc.getAddress(),
+            await jusd.getAddress(),
+            0,
+            amount,
+            ethers.parseEther("1000"),
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+      });
+
+      it("Should revert with InvalidTokenPair for two bridged tokens", async function () {
+        const { gateway, user1, usdc, usdt } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const amount = 1000n * 10n ** 6n;
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), amount);
+        await usdt.connect(user1).approve(await gateway.getAddress(), amount);
+
+        await expect(
+          gateway.connect(user1).addLiquidity(
+            await usdc.getAddress(),
+            await usdt.getAddress(),
+            0,
+            amount,
+            amount,
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+        ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+      });
+    });
+
+    describe("View Functions", function () {
+      it("Should convert bridged token amount to svJUSD", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const usdcAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
+        const jusdEquivalent = ethers.parseEther("1000"); // 1000 JUSD (18 decimals)
+        const expectedSvJusd = await svJusd.convertToShares(jusdEquivalent);
+
+        const result = await gateway.bridgedToSvJusd(await usdc.getAddress(), usdcAmount);
+        expect(result).to.equal(expectedSvJusd);
+      });
+
+      it("Should convert svJUSD amount to bridged token", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const svJusdAmount = ethers.parseEther("1000");
+        const jusdEquivalent = await svJusd.convertToAssets(svJusdAmount);
+        // 1000 JUSD (18 decimals) = 1000 USDC (6 decimals)
+        const expectedUsdc = 1000n * 10n ** 6n;
+
+        const result = await gateway.svJusdToBridged(await usdc.getAddress(), svJusdAmount);
+        expect(result).to.equal(expectedUsdc);
+      });
+
+      it("Should return true for supported bridged token", async function () {
+        const { gateway, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+        expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.true;
+      });
+
+      it("Should return false for non-bridged token", async function () {
+        const { gateway, wcbtc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+        expect(await gateway.isBridgedToken(await wcbtc.getAddress())).to.be.false;
+      });
+
+      it("Should revert bridgedToSvJusd for non-bridged token", async function () {
+        const { gateway, wcbtc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.bridgedToSvJusd(await wcbtc.getAddress(), 1000)
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+      });
+
+      it("Should revert svJusdToBridged for non-bridged token", async function () {
+        const { gateway, wcbtc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        await expect(
+          gateway.svJusdToBridged(await wcbtc.getAddress(), ethers.parseEther("1000"))
+        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+      });
+    });
+
+    describe("Decimal Conversion", function () {
+      it("Should correctly convert 6 decimal token to 18 decimal JUSD", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // 1 USDC (6 decimals) = 1 JUSD (18 decimals)
+        const usdcAmount = 1n * 10n ** 6n; // 1 USDC
+        const expectedJusdEquivalent = ethers.parseEther("1"); // 1 JUSD
+        const expectedSvJusd = await svJusd.convertToShares(expectedJusdEquivalent);
+
+        const result = await gateway.bridgedToSvJusd(await usdc.getAddress(), usdcAmount);
+        expect(result).to.equal(expectedSvJusd);
+      });
+
+      it("Should correctly convert 18 decimal JUSD to 6 decimal token", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // 1 JUSD (18 decimals) = 1 USDC (6 decimals)
+        const svJusdAmount = await svJusd.convertToShares(ethers.parseEther("1"));
+        const expectedUsdc = 1n * 10n ** 6n; // 1 USDC
+
+        const result = await gateway.svJusdToBridged(await usdc.getAddress(), svJusdAmount);
+        expect(result).to.equal(expectedUsdc);
+      });
+
+      it("Should handle large amounts correctly", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // 1,000,000 USDC
+        const usdcAmount = 1_000_000n * 10n ** 6n;
+        const expectedJusdEquivalent = ethers.parseEther("1000000");
+        const expectedSvJusd = await svJusd.convertToShares(expectedJusdEquivalent);
+
+        const result = await gateway.bridgedToSvJusd(await usdc.getAddress(), usdcAmount);
+        expect(result).to.equal(expectedSvJusd);
+      });
+
+      it("Should handle small amounts with precision loss", async function () {
+        const { gateway, usdc, svJusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Very small amount: 1 wei of svJUSD converted to USDC
+        // This tests that precision loss is handled (rounds down to 0)
+        const svJusdAmount = 1n; // 1 wei
+        const result = await gateway.svJusdToBridged(await usdc.getAddress(), svJusdAmount);
+        // 1 wei JUSD = 0 USDC (too small)
+        expect(result).to.equal(0n);
+      });
+    });
+
+    describe("Multiple Bridged Tokens", function () {
+      it("Should support swapping between different bridged tokens via pool", async function () {
+        const { gateway, user1, usdc, usdt, svJusd, swapRouter, usdtBridge } =
+          await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = 1000n * 10n ** 6n; // 1000 USDC
+
+        // Mock: USDC → svJUSD → USDT path
+        // Router returns svJUSD, then gateway converts to USDT
+        const svJusdOutput = ethers.parseEther("1000");
+        await swapRouter.setSwapOutput(svJusdOutput);
+        await usdtBridge.setMinted(svJusdOutput);
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        const usdtBefore = await usdt.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await usdt.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const usdtAfter = await usdt.balanceOf(user1.address);
+        expect(usdtAfter - usdtBefore).to.equal(1000n * 10n ** 6n);
+      });
+
+      it("Should handle all three bridged tokens independently", async function () {
+        const { gateway, usdc, usdt, ctUsd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // All three should be recognized as bridged tokens
+        expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.true;
+        expect(await gateway.isBridgedToken(await usdt.getAddress())).to.be.true;
+        expect(await gateway.isBridgedToken(await ctUsd.getAddress())).to.be.true;
+
+        // Each should have correct bridge config
+        const tokens = await gateway.getBridgedTokens();
+        expect(tokens.length).to.equal(3);
+      });
+    });
+
+    describe("getBridgeStatus", function () {
+      const bridgeAmount = 10_000_000n * 10n ** 6n; // 10M with 6 decimals (from fixture)
+
+      it("Should return healthy status for properly configured bridge", async function () {
+        const { gateway, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.true;
+        expect(status.canBurn).to.be.true;
+        expect(status.mintCapacity).to.equal(BRIDGE_LIMIT);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return unsupported status for unknown token", async function () {
+        const { gateway } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Use a random address that's not a bridged token
+        const randomAddress = ethers.Wallet.createRandom().address;
+        const status = await gateway.getBridgeStatus(randomAddress);
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.false;
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(0);
+        expect(status.mintBlockReason).to.equal("Token not supported");
+        expect(status.burnBlockReason).to.equal("Token not supported");
+      });
+
+      it("Should return stopped status when bridge is stopped", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Stop the bridge
+        await usdcBridge.setStopped(true);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.true; // Burn should still work
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(bridgeAmount); // Bridge still has liquidity
+        expect(status.mintBlockReason).to.equal("Bridge stopped");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return expired status when bridge horizon is passed", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Get the bridge horizon and advance time past it
+        const horizon = await usdcBridge.horizon();
+        await time.increaseTo(horizon + 1n);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.true; // Burn should still work
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("Bridge expired");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return limit reached when mint limit is exhausted", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Set minted to the limit
+        await usdcBridge.setMinted(BRIDGE_LIMIT);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.true; // Burn should still work
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("Limit reached");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should return insufficient liquidity when bridge has no tokens", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        // Deploy a new bridged token with empty bridge
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        // Add to gateway but don't fund the bridge
+        await gateway.connect(owner).addBridgedToken(await newToken.getAddress(), await newBridge.getAddress());
+
+        const status = await gateway.getBridgeStatus(await newToken.getAddress());
+
+        expect(status.canMint).to.be.true; // Can still mint
+        expect(status.canBurn).to.be.false; // Can't burn without liquidity
+        expect(status.mintCapacity).to.equal(BRIDGE_LIMIT);
+        expect(status.burnCapacity).to.equal(0);
+        expect(status.mintBlockReason).to.equal("");
+        expect(status.burnBlockReason).to.equal("Insufficient bridge liquidity");
+      });
+
+      it("Should return accurate remaining mint capacity", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        // Set minted to 40% of limit
+        const mintedAmount = BRIDGE_LIMIT * 40n / 100n;
+        await usdcBridge.setMinted(mintedAmount);
+
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+        expect(status.canMint).to.be.true;
+        expect(status.canBurn).to.be.true;
+        expect(status.mintCapacity).to.equal(BRIDGE_LIMIT - mintedAmount);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
+        expect(status.mintBlockReason).to.equal("");
+        expect(status.burnBlockReason).to.equal("");
+      });
+
+      it("Should handle combined failure: stopped bridge with no liquidity", async function () {
+        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        // Deploy a new bridged token with empty bridge
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        // Add to gateway but don't fund the bridge
+        await gateway.connect(owner).addBridgedToken(await newToken.getAddress(), await newBridge.getAddress());
+
+        // Stop the bridge
+        await newBridge.setStopped(true);
+
+        const status = await gateway.getBridgeStatus(await newToken.getAddress());
+
+        // Both mint and burn should be blocked for different reasons
+        expect(status.canMint).to.be.false;
+        expect(status.canBurn).to.be.false;
+        expect(status.mintCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(0);
+        expect(status.mintBlockReason).to.equal("Bridge stopped");
+        expect(status.burnBlockReason).to.equal("Insufficient bridge liquidity");
+      });
     });
   });
 });


### PR DESCRIPTION
* feat(gateway): add bridged stablecoin (USDT) support

- Add IStablecoinBridge interface for StablecoinBridge integration
- Extend Gateway to convert bridged USD (e.g., USDT) to svJUSD via Bridge
- Add BRIDGED_USD, STABLECOIN_BRIDGE state variables and constructor params
- Implement _handleTokenIn/Out for USDT → JUSD → svJUSD conversion flow
- Add InvalidTokenPair error to prevent USDT+JUSD pairs (both map to svJUSD)
- Add bridgedUsdToSvJusd/svJusdToBridgedUsd view functions
- Add decimal conversion helpers for 6↔18 decimal handling

* fix(gateway): add JUSD approval for StablecoinBridge burn operations

Without this approval, burnAndSend calls would revert when users try to swap or withdraw to bridged USD (e.g., USDT).

* fix(gateway): use SafeERC20.safeTransferFrom for arbitrary tokens

Some tokens (like USDT) don't return a bool on transfer, which would cause the standard transferFrom to revert. SafeERC20 handles this.

* feat(gateway): support multiple bridged stablecoins via mapping

Replace single immutable BRIDGED_USD with flexible mapping-based approach:
- Add BridgeConfig struct with bridge address and decimals
- Add bridgeConfigs mapping for token → bridge lookup
- Add addBridgedToken/removeBridgedToken admin functions
- Update all internal functions to use mapping lookup
- Rename view functions: bridgedToSvJusd, svJusdToBridged (with token param)
- Add isBridgedToken and getBridgedTokens view functions
- Simplify constructor (bridged tokens added post-deployment)

Supports USDC.e, USDT.e, ctUSD and future bridged stablecoins.

* test(gateway): add comprehensive tests for bridged token support

Add MockStablecoinBridge contract for testing bridge operations.

Tests cover:
- Admin functions (addBridgedToken, removeBridgedToken, getBridgedTokens)
- Swap with bridged tokens as input and output
- Add liquidity with bridged tokens
- InvalidTokenPair validation (bridged+JUSD, bridged+bridged)
- View functions (bridgedToSvJusd, svJusdToBridged, isBridgedToken)
- Decimal conversion (6 decimals ↔ 18 decimals)
- Multiple bridged tokens (USDC.e, USDT.e, ctUSD)

25 new tests, all passing.

* fix(gateway): add safety improvements for bridged token handling

- Add MAX_BRIDGED_TOKENS (10) limit to prevent unbounded array growth
- Add TooManyBridgedTokens error
- Replace unreachable else-branch in _returnExcess with explicit revert
- Add test for TooManyBridgedTokens limit

26 bridged token tests passing.

* docs(gateway): add detailed NatSpec for decimal conversion functions

Document rounding behavior in _bridgedToJusdAmount, _jusdToBridgedAmount, and _bridgedToSvJusdAmount. Clarifies that floor division is intentional to favor the protocol on withdrawals (standard DeFi practice).

* feat(gateway): add getBridgeStatus view function for bridge health checks

Add comprehensive status reporting for bridged token bridges:
- canMint/canBurn: Whether operations are currently possible
- mintCapacity: Remaining JUSD that can be minted through bridge
- burnCapacity: Available bridged tokens for withdrawals
- Human-readable block reasons (stopped, expired, limit reached, insufficient liquidity)

Enables frontends to check bridge health before attempting operations, preventing failed transactions and improving UX.

* add a few more getBridgeStatus unit tests

* use SafeERC20 in rescueToken for non-standard token compatibility

* revoke JUSD approval when removing bridged token

* validate bridge token configuration in addBridgedToken

---------