### PR TITLE
Trustless Gateway, add pool creation, JUICE support, and gas-optimize…

### DIFF
--- a/contracts/JuiceSwapGateway.sol
+++ b/contracts/JuiceSwapGateway.sol
@@ -8,9 +8,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 
 interface IWrappedCBTC is IERC20 {
     function deposit() external payable;
@@ -20,8 +18,18 @@ interface IWrappedCBTC is IERC20 {
 interface IEquity is IERC20 {
     function invest(uint256 amount, uint256 expectedShares) external returns (uint256);
     function redeem(address target, uint256 shares) external returns (uint256);
+    function redeemFrom(
+        address owner,
+        address target,
+        uint256 shares,
+        uint256 expectedProceeds
+    ) external returns (uint256);
     function calculateProceeds(uint256 shares) external view returns (uint256);
     function calculateShares(uint256 investment) external view returns (uint256);
+}
+
+interface IJuiceDollar {
+    function isMinter(address minter) external view returns (bool);
 }
 
 interface ISwapRouter {
@@ -49,6 +57,7 @@ interface ISwapRouter {
 
 interface IUniswapV3Factory {
     function feeAmountTickSpacing(uint24 fee) external view returns (int24);
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool);
 }
 
 interface INonfungiblePositionManager {
@@ -67,10 +76,9 @@ interface INonfungiblePositionManager {
         uint256 deadline;
     }
 
-    function mint(MintParams calldata params)
-        external
-        payable
-        returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
+    function mint(
+        MintParams calldata params
+    ) external payable returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1);
 
     struct IncreaseLiquidityParams {
         uint256 tokenId;
@@ -81,10 +89,9 @@ interface INonfungiblePositionManager {
         uint256 deadline;
     }
 
-    function increaseLiquidity(IncreaseLiquidityParams calldata params)
-        external
-        payable
-        returns (uint128 liquidity, uint256 amount0, uint256 amount1);
+    function increaseLiquidity(
+        IncreaseLiquidityParams calldata params
+    ) external payable returns (uint128 liquidity, uint256 amount0, uint256 amount1);
 
     struct DecreaseLiquidityParams {
         uint256 tokenId;
@@ -94,10 +101,9 @@ interface INonfungiblePositionManager {
         uint256 deadline;
     }
 
-    function decreaseLiquidity(DecreaseLiquidityParams calldata params)
-        external
-        payable
-        returns (uint256 amount0, uint256 amount1);
+    function decreaseLiquidity(
+        DecreaseLiquidityParams calldata params
+    ) external payable returns (uint256 amount0, uint256 amount1);
 
     struct CollectParams {
         uint256 tokenId;
@@ -108,7 +114,9 @@ interface INonfungiblePositionManager {
 
     function collect(CollectParams calldata params) external payable returns (uint256 amount0, uint256 amount1);
 
-    function positions(uint256 tokenId)
+    function positions(
+        uint256 tokenId
+    )
         external
         view
         returns (
@@ -125,6 +133,13 @@ interface INonfungiblePositionManager {
             uint128 tokensOwed0,
             uint128 tokensOwed1
         );
+
+    function createAndInitializePoolIfNecessary(
+        address token0,
+        address token1,
+        uint24 fee,
+        uint160 sqrtPriceX96
+    ) external payable returns (address pool);
 }
 
 /**
@@ -142,7 +157,7 @@ interface INonfungiblePositionManager {
  *      The addLiquidity/removeLiquidity functions are simplified wrappers.
  *      Advanced users should interact with the NonfungiblePositionManager directly.
  */
-contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausable {
+contract JuiceSwapGateway is IJuiceSwapGateway, ReentrancyGuard {
     IERC20 public immutable JUSD;
     IERC4626 public immutable SV_JUSD;
     IEquity public immutable JUICE;
@@ -161,37 +176,33 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     mapping(address => BridgeConfig) public bridgeConfigs;
     /// @notice List of all supported bridged tokens (for enumeration)
     address[] public bridgedTokens;
-    /// @notice Maximum number of bridged tokens that can be added
-    uint8 public constant MAX_BRIDGED_TOKENS = 10;
     /// @notice Decimals of JUSD (cached for gas efficiency)
     uint8 public immutable JUSD_DECIMALS;
 
     address private constant NATIVE_TOKEN = address(0);
-    uint24 public defaultFee = 3000; // 0.3% default fee tier
+    uint24 public constant DEFAULT_FEE = 3000; // 0.3% default fee tier (immutable)
+    int24 private constant MIN_TICK = -887272;
+    int24 private constant MAX_TICK = 887272;
 
     error InvalidToken();
     error InvalidAmount();
     error InsufficientOutput();
-    error SlippageExceeded();
     error TransferFailed();
     error DeadlineExpired();
     error DirectTransferNotAccepted();
-    error JuiceInputNotSupported();
     error NotNFTOwner(address caller, address owner);
     error InvalidFee(uint24 fee);
     error TokenMismatch(address expected0, address expected1, address provided0, address provided1);
     error InsufficientLiquidity(uint128 requested, uint128 available);
     error InvalidTokenPair(address tokenA, address tokenB);
+    error JuiceCannotPairWithUsd(address usdToken);
+    error InvalidTickRange(int24 tickLower, int24 tickUpper);
     error BridgedTokenAlreadyExists(address token);
     error BridgedTokenNotFound(address token);
     error InvalidBridgeConfig();
-    error TooManyBridgedTokens();
-
-    event TokenRescued(address indexed token, address indexed to, uint256 amount);
-    event NativeRescued(address indexed to, uint256 amount);
-    event DefaultFeeUpdated(uint24 oldFee, uint24 newFee);
-    event BridgedTokenAdded(address indexed token, address indexed bridge, uint8 decimals);
-    event BridgedTokenRemoved(address indexed token);
+    error BridgeNotApprovedMinter(address bridge);
+    error BridgeStopped(address bridge);
+    error InvalidPrice();
 
     /**
      * @notice Initializes the JuiceSwap Gateway for Uniswap V3
@@ -209,7 +220,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         address _wcbtc,
         address _swapRouter,
         address _positionManager
-    ) Ownable(msg.sender) {
+    ) {
         JUSD = IERC20(_jusd);
         SV_JUSD = IERC4626(_svJusd);
         JUICE = IEquity(_juice);
@@ -226,6 +237,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         IERC20(_svJusd).approve(_positionManager, type(uint256).max);
         IERC20(_wcbtc).approve(_swapRouter, type(uint256).max);
         IERC20(_wcbtc).approve(_positionManager, type(uint256).max);
+        IERC20(_juice).approve(_positionManager, type(uint256).max); // For JUICE liquidity pools
     }
 
     /**
@@ -240,12 +252,24 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         uint256 minAmountOut,
         address to,
         uint256 deadline
-    ) external payable nonReentrant whenNotPaused returns (uint256 amountOut) {
+    ) external payable nonReentrant returns (uint256 amountOut) {
         if (block.timestamp > deadline) revert DeadlineExpired();
         if (amountIn == 0) revert InvalidAmount();
 
-        // Use defaultFee when fee is 0 (JUICE1-6 fix)
-        uint24 effectiveFee = fee == 0 ? defaultFee : fee;
+        // Optimization: Handle direct USD conversions without svJUSD roundtrip
+        // This saves ~100k gas for JUSD <-> Bridged and JUSD/Bridged -> JUICE swaps
+        bool isInputUsd = _isUsdToken(tokenIn);
+        bool isOutputUsdOrJuice = _isUsdToken(tokenOut) || tokenOut == address(JUICE);
+
+        if (isInputUsd && isOutputUsdOrJuice && tokenIn != tokenOut) {
+            amountOut = _handleDirectUsdConversion(tokenIn, tokenOut, amountIn, to);
+            if (amountOut < minAmountOut) revert InsufficientOutput();
+            emit SwapExecuted(msg.sender, tokenIn, tokenOut, amountIn, amountOut);
+            return amountOut;
+        }
+
+        // Use DEFAULT_FEE when fee is 0 (JUICE1-6 fix)
+        uint24 effectiveFee = fee == 0 ? DEFAULT_FEE : fee;
         if (effectiveFee >= 1_000_000) revert InvalidFee(effectiveFee);
 
         // Step 1: Handle input token conversion
@@ -254,18 +278,24 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Step 2: Handle output token conversion
         address actualTokenOut = _getActualToken(tokenOut);
 
-        // Step 3: Execute swap through Uniswap V3 SwapRouter
-        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
-            tokenIn: actualTokenIn,
-            tokenOut: actualTokenOut,
-            fee: effectiveFee,
-            recipient: address(this),
-            amountIn: actualAmountIn,
-            amountOutMinimum: 0, // Slippage checked after conversions
-            sqrtPriceLimitX96: 0
-        });
-
-        uint256 actualAmountOut = SWAP_ROUTER.exactInputSingle(params);
+        // Step 3: Execute swap through Uniswap V3 SwapRouter (skip if same token)
+        // Note: The direct USD conversion above handles most same-token cases more efficiently
+        uint256 actualAmountOut;
+        if (actualTokenIn == actualTokenOut) {
+            // Fallback for edge cases (shouldn't happen with USD tokens anymore)
+            actualAmountOut = actualAmountIn;
+        } else {
+            ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
+                tokenIn: actualTokenIn,
+                tokenOut: actualTokenOut,
+                fee: effectiveFee,
+                recipient: address(this),
+                amountIn: actualAmountIn,
+                amountOutMinimum: 0, // Slippage checked after conversions
+                sqrtPriceLimitX96: 0
+            });
+            actualAmountOut = SWAP_ROUTER.exactInputSingle(params);
+        }
 
         // Step 4: Convert output token back to user-facing token
         amountOut = _handleTokenOut(tokenOut, actualAmountOut, to);
@@ -277,61 +307,84 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     }
 
     /**
-     * @notice Adds liquidity with automatic JUSD→svJUSD conversion
-     * @dev For Uniswap V3, this creates a full-range position. For custom ranges, use Position Manager directly.
+     * @notice Adds liquidity with automatic JUSD→svJUSD conversion and optional custom tick range
+     * @dev If tickLower == tickUpper, creates a full-range position. Otherwise validates and uses custom ticks.
      */
     function addLiquidity(
         address tokenA,
         address tokenB,
         uint24 fee,
+        int24 tickLower,
+        int24 tickUpper,
         uint256 amountADesired,
         uint256 amountBDesired,
         uint256 amountAMin,
         uint256 amountBMin,
         address to,
         uint256 deadline
-    ) external payable nonReentrant whenNotPaused returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
+    ) external payable nonReentrant returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
         if (block.timestamp > deadline) revert DeadlineExpired();
+
+        // JUICE liquidity restriction: cannot pair with USD-based tokens
+        // (JUICE/svJUSD pool would be redundant since JUICE can be redeemed for JUSD)
+        if (tokenA == address(JUICE) || tokenB == address(JUICE)) {
+            address otherToken = tokenA == address(JUICE) ? tokenB : tokenA;
+            if (
+                otherToken == address(JUSD) ||
+                otherToken == address(SV_JUSD) ||
+                address(bridgeConfigs[otherToken].bridge) != address(0)
+            ) {
+                revert JuiceCannotPairWithUsd(otherToken);
+            }
+        }
 
         // Prevent invalid token pairs where both tokens convert to the same actual token
         // e.g., USDT + JUSD would both become svJUSD
-        if (_getActualToken(tokenA) == _getActualToken(tokenB)) {
+        // Note: Use _getActualTokenForLiquidity since JUICE stays JUICE for liquidity
+        if (_getActualTokenForLiquidity(tokenA) == _getActualTokenForLiquidity(tokenB)) {
             revert InvalidTokenPair(tokenA, tokenB);
         }
 
-        // Use defaultFee when fee is 0 (JUICE1-6 fix)
-        uint24 effectiveFee = fee == 0 ? defaultFee : fee;
+        // Use DEFAULT_FEE when fee is 0 (JUICE1-6 fix)
+        uint24 effectiveFee = fee == 0 ? DEFAULT_FEE : fee;
 
-        // Convert input tokens
-        (address actualTokenA, uint256 actualAmountADesired) = _handleTokenIn(tokenA, amountADesired);
-        (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenIn(tokenB, amountBDesired);
+        // Convert input tokens (JUICE stays JUICE for liquidity, not converted to svJUSD)
+        (address actualTokenA, uint256 actualAmountADesired) = _handleTokenInForLiquidity(tokenA, amountADesired);
+        (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenInForLiquidity(tokenB, amountBDesired);
 
         // Cache token ordering comparison (JUICE1-11 fix)
         bool isAToken0 = actualTokenA < actualTokenB;
 
         // Ensure token0 < token1 (Uniswap V3 requirement)
-        (address token0, address token1, uint256 amount0Desired, uint256 amount1Desired) =
-            isAToken0
-                ? (actualTokenA, actualTokenB, actualAmountADesired, actualAmountBDesired)
-                : (actualTokenB, actualTokenA, actualAmountBDesired, actualAmountADesired);
+        (address token0, address token1, uint256 amount0Desired, uint256 amount1Desired) = isAToken0
+            ? (actualTokenA, actualTokenB, actualAmountADesired, actualAmountBDesired)
+            : (actualTokenB, actualTokenA, actualAmountBDesired, actualAmountADesired);
 
-        // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
-        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
+        // Calculate minimum amounts for actual tokens (JUICE stays JUICE for liquidity)
+        uint256 actualAmountAMin = _toActualMinAmountForLiquidity(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmountForLiquidity(tokenB, amountBMin);
 
-        (uint256 amount0Min, uint256 amount1Min) =
-            isAToken0
-                ? (actualAmountAMin, actualAmountBMin)
-                : (actualAmountBMin, actualAmountAMin);
+        (uint256 amount0Min, uint256 amount1Min) = isAToken0
+            ? (actualAmountAMin, actualAmountBMin)
+            : (actualAmountBMin, actualAmountAMin);
 
-        (int24 tickLower, int24 tickUpper) = _getFullRangeTicks(effectiveFee);
+        // Determine tick range: if tickLower == tickUpper (sentinel), use full range
+        int24 actualTickLower;
+        int24 actualTickUpper;
+        if (tickLower == tickUpper) {
+            (actualTickLower, actualTickUpper) = _getFullRangeTicks(effectiveFee);
+        } else {
+            _validateTicks(tickLower, tickUpper, effectiveFee);
+            actualTickLower = tickLower;
+            actualTickUpper = tickUpper;
+        }
 
         INonfungiblePositionManager.MintParams memory params = INonfungiblePositionManager.MintParams({
             token0: token0,
             token1: token1,
             fee: effectiveFee,
-            tickLower: tickLower,
-            tickUpper: tickUpper,
+            tickLower: actualTickLower,
+            tickUpper: actualTickUpper,
             amount0Desired: amount0Desired,
             amount1Desired: amount1Desired,
             amount0Min: amount0Min,
@@ -342,8 +395,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
 
         (uint256 tokenId, , uint256 amount0, uint256 amount1) = POSITION_MANAGER.mint(params);
 
-        // Map back to A/B order
-        (amountA, amountB) = isAToken0 ? (amount0, amount1) : (amount1, amount0);
+        // Map back to A/B order (in pool token units)
+        (uint256 poolAmountA, uint256 poolAmountB) = isAToken0 ? (amount0, amount1) : (amount1, amount0);
         liquidity = tokenId; // Return NFT tokenId as "liquidity"
 
         // Return excess tokens to user
@@ -356,6 +409,14 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
 
         _returnExcess(tokenA, actualTokenA, excessA, msg.sender);
         _returnExcess(tokenB, actualTokenB, excessB, msg.sender);
+
+        // Convert to user-facing amounts for return values and event
+        amountA = _toUserAmountForLiquidity(tokenA, poolAmountA);
+        amountB = _toUserAmountForLiquidity(tokenB, poolAmountB);
+
+        // Verify final amounts meet user's minimums after all conversions
+        if (amountA < amountAMin) revert InsufficientOutput();
+        if (amountB < amountBMin) revert InsufficientOutput();
 
         emit LiquidityAdded(msg.sender, tokenA, tokenB, amountA, amountB, tokenId);
         return (amountA, amountB, liquidity);
@@ -374,20 +435,33 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         uint256 amountAMin,
         uint256 amountBMin,
         uint256 deadline
-    ) external payable nonReentrant whenNotPaused returns (uint256 amountA, uint256 amountB, uint128 liquidity) {
+    ) external payable nonReentrant returns (uint256 amountA, uint256 amountB, uint128 liquidity) {
         if (block.timestamp > deadline) revert DeadlineExpired();
+
+        // JUICE liquidity restriction: cannot pair with USD-based tokens
+        if (tokenA == address(JUICE) || tokenB == address(JUICE)) {
+            address otherToken = tokenA == address(JUICE) ? tokenB : tokenA;
+            if (
+                otherToken == address(JUSD) ||
+                otherToken == address(SV_JUSD) ||
+                address(bridgeConfigs[otherToken].bridge) != address(0)
+            ) {
+                revert JuiceCannotPairWithUsd(otherToken);
+            }
+        }
 
         // Verify NFT ownership
         address nftOwner = IERC721(address(POSITION_MANAGER)).ownerOf(tokenId);
         if (nftOwner != msg.sender) revert NotNFTOwner(msg.sender, nftOwner);
 
         // Validate tokens match position BEFORE any transfers (positions() is a view function)
-        (,, address posToken0, address posToken1,,,,,,,,) = POSITION_MANAGER.positions(tokenId);
-        address expectedTokenA = _getActualToken(tokenA);
-        address expectedTokenB = _getActualToken(tokenB);
+        // Note: Use _getActualTokenForLiquidity since JUICE stays JUICE for liquidity
+        (, , address posToken0, address posToken1, , , , , , , , ) = POSITION_MANAGER.positions(tokenId);
+        address expectedTokenA = _getActualTokenForLiquidity(tokenA);
+        address expectedTokenB = _getActualTokenForLiquidity(tokenB);
 
         bool tokensMatch = (expectedTokenA == posToken0 && expectedTokenB == posToken1) ||
-                           (expectedTokenA == posToken1 && expectedTokenB == posToken0);
+            (expectedTokenA == posToken1 && expectedTokenB == posToken0);
         if (!tokensMatch) {
             revert TokenMismatch(posToken0, posToken1, expectedTokenA, expectedTokenB);
         }
@@ -395,19 +469,19 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Transfer NFT to this contract (only after validation passes)
         IERC721(address(POSITION_MANAGER)).transferFrom(msg.sender, address(this), tokenId);
 
-        // Convert input tokens (JUSD/bridged USD → svJUSD)
-        (address actualTokenA, uint256 actualAmountADesired) = _handleTokenIn(tokenA, amountADesired);
-        (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenIn(tokenB, amountBDesired);
+        // Convert input tokens (JUICE stays JUICE for liquidity, JUSD/bridged USD → svJUSD)
+        (address actualTokenA, uint256 actualAmountADesired) = _handleTokenInForLiquidity(tokenA, amountADesired);
+        (address actualTokenB, uint256 actualAmountBDesired) = _handleTokenInForLiquidity(tokenB, amountBDesired);
 
-        // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
-        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
+        // Calculate minimum amounts for actual tokens (JUICE stays JUICE for liquidity)
+        uint256 actualAmountAMin = _toActualMinAmountForLiquidity(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmountForLiquidity(tokenB, amountBMin);
 
         // Cache token ordering comparison
         bool isAToken0 = actualTokenA < actualTokenB;
 
-        INonfungiblePositionManager.IncreaseLiquidityParams memory params =
-            INonfungiblePositionManager.IncreaseLiquidityParams({
+        INonfungiblePositionManager.IncreaseLiquidityParams memory params = INonfungiblePositionManager
+            .IncreaseLiquidityParams({
                 tokenId: tokenId,
                 amount0Desired: isAToken0 ? actualAmountADesired : actualAmountBDesired,
                 amount1Desired: isAToken0 ? actualAmountBDesired : actualAmountADesired,
@@ -423,10 +497,6 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Map back to A/B order
         (amountA, amountB) = isAToken0 ? (amount0, amount1) : (amount1, amount0);
 
-        // Defense-in-depth slippage check (PM enforces internally, kept for non-conforming implementations)
-        if (amountA < actualAmountAMin) revert SlippageExceeded();
-        if (amountB < actualAmountBMin) revert SlippageExceeded();
-
         // Return excess tokens to user
         uint256 excessA = isAToken0
             ? (actualAmountADesired > amount0 ? actualAmountADesired - amount0 : 0)
@@ -439,9 +509,13 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         _returnExcess(tokenB, actualTokenB, excessB, msg.sender);
 
         // Convert amounts back to user-facing token units for return values and event
-        // (amountA/amountB are currently in svJUSD terms if user passed JUSD or bridged USD)
-        uint256 userAmountA = _toUserAmount(tokenA, amountA);
-        uint256 userAmountB = _toUserAmount(tokenB, amountB);
+        // (amountA/amountB are in svJUSD terms if user passed JUSD or bridged USD, or JUICE if JUICE liquidity)
+        uint256 userAmountA = _toUserAmountForLiquidity(tokenA, amountA);
+        uint256 userAmountB = _toUserAmountForLiquidity(tokenB, amountB);
+
+        // Verify final amounts meet user's minimums after all conversions
+        if (userAmountA < amountAMin) revert InsufficientOutput();
+        if (userAmountB < amountBMin) revert InsufficientOutput();
 
         // Return NFT to user
         IERC721(address(POSITION_MANAGER)).safeTransferFrom(address(this), msg.sender, tokenId);
@@ -464,15 +538,16 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         uint256 amountBMin,
         address to,
         uint256 deadline
-    ) external nonReentrant whenNotPaused returns (uint256 amountA, uint256 amountB) {
+    ) external nonReentrant returns (uint256 amountA, uint256 amountB) {
         if (block.timestamp > deadline) revert DeadlineExpired();
 
         // Verify NFT ownership to prevent theft
         address nftOwner = IERC721(address(POSITION_MANAGER)).ownerOf(tokenId);
         if (nftOwner != msg.sender) revert NotNFTOwner(msg.sender, nftOwner);
 
-        // Get position info to determine liquidity amount
-        (,,,,,,, uint128 positionLiquidity,,,,) = POSITION_MANAGER.positions(tokenId);
+        // Get position info including actual tokens in the pool
+        (, , address posToken0, address posToken1, , , , uint128 positionLiquidity, , , , ) = POSITION_MANAGER
+            .positions(tokenId);
 
         // Use specified amount or full position liquidity
         uint128 liquidityAmount = liquidityToRemove == 0 ? positionLiquidity : liquidityToRemove;
@@ -485,12 +560,40 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Transfer NFT to this contract
         IERC721(address(POSITION_MANAGER)).transferFrom(msg.sender, address(this), tokenId);
 
-        address actualTokenA = _getActualToken(tokenA);
-        address actualTokenB = _getActualToken(tokenB);
+        // Determine if position has JUICE (JUICE liquidity pool) or svJUSD (swap-style pool)
+        // This affects which conversion function to use
+        bool positionHasJuice = posToken0 == address(JUICE) || posToken1 == address(JUICE);
+
+        // Map user tokens to actual position tokens based on what the position contains
+        address actualTokenA;
+        address actualTokenB;
+        if (positionHasJuice) {
+            // JUICE liquidity pool: JUICE stays JUICE
+            actualTokenA = _getActualTokenForLiquidity(tokenA);
+            actualTokenB = _getActualTokenForLiquidity(tokenB);
+        } else {
+            // Swap-style pool: use swap token mapping (JUICE → svJUSD)
+            actualTokenA = _getActualToken(tokenA);
+            actualTokenB = _getActualToken(tokenB);
+        }
+
+        // Validate tokens match the position
+        bool tokensMatch = (actualTokenA == posToken0 && actualTokenB == posToken1) ||
+            (actualTokenA == posToken1 && actualTokenB == posToken0);
+        if (!tokensMatch) {
+            revert TokenMismatch(posToken0, posToken1, actualTokenA, actualTokenB);
+        }
 
         // Calculate minimum amounts for actual tokens
-        uint256 actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
-        uint256 actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
+        uint256 actualAmountAMin;
+        uint256 actualAmountBMin;
+        if (positionHasJuice) {
+            actualAmountAMin = _toActualMinAmountForLiquidity(tokenA, amountAMin);
+            actualAmountBMin = _toActualMinAmountForLiquidity(tokenB, amountBMin);
+        } else {
+            actualAmountAMin = _toActualMinAmount(tokenA, amountAMin);
+            actualAmountBMin = _toActualMinAmount(tokenB, amountBMin);
+        }
 
         // Determine token order
         bool isAToken0 = actualTokenA < actualTokenB;
@@ -499,8 +602,8 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             : (actualAmountBMin, actualAmountAMin);
 
         // Decrease liquidity (partial or full)
-        INonfungiblePositionManager.DecreaseLiquidityParams memory decreaseParams =
-            INonfungiblePositionManager.DecreaseLiquidityParams({
+        INonfungiblePositionManager.DecreaseLiquidityParams memory decreaseParams = INonfungiblePositionManager
+            .DecreaseLiquidityParams({
                 tokenId: tokenId,
                 liquidity: liquidityAmount,
                 amount0Min: amount0Min,
@@ -511,13 +614,12 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         (uint256 amount0, uint256 amount1) = POSITION_MANAGER.decreaseLiquidity(decreaseParams);
 
         // Collect tokens
-        INonfungiblePositionManager.CollectParams memory collectParams =
-            INonfungiblePositionManager.CollectParams({
-                tokenId: tokenId,
-                recipient: address(this),
-                amount0Max: type(uint128).max,
-                amount1Max: type(uint128).max
-            });
+        INonfungiblePositionManager.CollectParams memory collectParams = INonfungiblePositionManager.CollectParams({
+            tokenId: tokenId,
+            recipient: address(this),
+            amount0Max: type(uint128).max,
+            amount1Max: type(uint128).max
+        });
 
         (amount0, amount1) = POSITION_MANAGER.collect(collectParams);
 
@@ -525,8 +627,16 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         (uint256 actualAmountA, uint256 actualAmountB) = isAToken0 ? (amount0, amount1) : (amount1, amount0);
 
         // Convert back to user-facing tokens
-        amountA = _handleTokenOut(tokenA, actualAmountA, to);
-        amountB = _handleTokenOut(tokenB, actualAmountB, to);
+        // Use appropriate handler based on position type
+        if (positionHasJuice) {
+            // JUICE liquidity pool: JUICE transferred directly
+            amountA = _handleTokenOutForLiquidity(tokenA, actualAmountA, to);
+            amountB = _handleTokenOutForLiquidity(tokenB, actualAmountB, to);
+        } else {
+            // Swap-style pool: convert svJUSD → user token (JUICE via invest)
+            amountA = _handleTokenOut(tokenA, actualAmountA, to);
+            amountB = _handleTokenOut(tokenB, actualAmountB, to);
+        }
 
         // Verify final amounts meet user's minimums after all conversions (JUICE1-4 fix)
         if (amountA < amountAMin) revert InsufficientOutput();
@@ -586,14 +696,15 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
 
         // Check if token is supported
         if (address(config.bridge) == address(0)) {
-            return BridgeStatus({
-                canMint: false,
-                canBurn: false,
-                mintCapacity: 0,
-                burnCapacity: 0,
-                mintBlockReason: "Token not supported",
-                burnBlockReason: "Token not supported"
-            });
+            return
+                BridgeStatus({
+                    canMint: false,
+                    canBurn: false,
+                    mintCapacity: 0,
+                    burnCapacity: 0,
+                    mintBlockReason: "Token not supported",
+                    burnBlockReason: "Token not supported"
+                });
         }
 
         IStablecoinBridge bridge = config.bridge;
@@ -603,7 +714,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         string memory mintReason = "";
         uint256 mintCapacity = 0;
 
-        // Check if bridge is stopped
+        // Check if bridge is stopped (emergency governance action)
         if (bridge.stopped()) {
             canMint = false;
             mintReason = "Bridge stopped";
@@ -634,14 +745,15 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         bool canBurn = bridgeBalance > 0;
         string memory burnReason = canBurn ? "" : "Insufficient bridge liquidity";
 
-        return BridgeStatus({
-            canMint: canMint,
-            canBurn: canBurn,
-            mintCapacity: mintCapacity,
-            burnCapacity: bridgeBalance,  // In bridged token decimals
-            mintBlockReason: mintReason,
-            burnBlockReason: burnReason
-        });
+        return
+            BridgeStatus({
+                canMint: canMint,
+                canBurn: canBurn,
+                mintCapacity: mintCapacity,
+                burnCapacity: bridgeBalance, // In bridged token decimals
+                mintBlockReason: mintReason,
+                burnBlockReason: burnReason
+            });
     }
 
     // ==================== Internal Functions ====================
@@ -649,7 +761,10 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     /**
      * @dev Handles input token conversion and returns the actual token to use in swaps
      */
-    function _handleTokenIn(address token, uint256 amount) internal returns (address actualToken, uint256 actualAmount) {
+    function _handleTokenIn(
+        address token,
+        uint256 amount
+    ) internal returns (address actualToken, uint256 actualAmount) {
         if (token == NATIVE_TOKEN) {
             // Native cBTC → WcBTC
             if (msg.value != amount) revert InvalidAmount();
@@ -661,9 +776,13 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             uint256 shares = SV_JUSD.deposit(amount, address(this));
             return (address(SV_JUSD), shares);
         } else if (token == address(JUICE)) {
-            // JUICE cannot be used as input due to Equity flash loan protection.
-            // Users must redeem JUICE directly: JUICE.redeem() → then swap the JUSD.
-            revert JuiceInputNotSupported();
+            // JUICE → JUSD via Equity.redeemFrom() → svJUSD
+            // Using redeemFrom() bypasses flash loan protection on Gateway address,
+            // since the check is on `owner` (msg.sender/user), not on `target` (Gateway).
+            // User must have approved Gateway for JUICE spending.
+            uint256 jusdAmount = JUICE.redeemFrom(msg.sender, address(this), amount, 0);
+            uint256 shares = SV_JUSD.deposit(jusdAmount, address(this));
+            return (address(SV_JUSD), shares);
         }
 
         // Check if token is a bridged stablecoin
@@ -684,6 +803,51 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             if (IERC20(token).allowance(address(this), address(SWAP_ROUTER)) < amount) {
                 SafeERC20.forceApprove(IERC20(token), address(SWAP_ROUTER), type(uint256).max);
             }
+            if (IERC20(token).allowance(address(this), address(POSITION_MANAGER)) < amount) {
+                SafeERC20.forceApprove(IERC20(token), address(POSITION_MANAGER), type(uint256).max);
+            }
+            return (token, amount);
+        }
+    }
+
+    /**
+     * @dev Handles input token conversion for liquidity operations
+     * @notice Unlike _handleTokenIn, JUICE is NOT converted to svJUSD - it stays as JUICE.
+     *         This allows users to add JUICE directly to liquidity pools.
+     */
+    function _handleTokenInForLiquidity(
+        address token,
+        uint256 amount
+    ) internal returns (address actualToken, uint256 actualAmount) {
+        if (token == NATIVE_TOKEN) {
+            // Native cBTC → WcBTC
+            if (msg.value != amount) revert InvalidAmount();
+            WCBTC.deposit{value: amount}();
+            return (address(WCBTC), amount);
+        } else if (token == address(JUSD)) {
+            // JUSD → svJUSD
+            JUSD.transferFrom(msg.sender, address(this), amount);
+            uint256 shares = SV_JUSD.deposit(amount, address(this));
+            return (address(SV_JUSD), shares);
+        } else if (token == address(JUICE)) {
+            // JUICE stays JUICE for liquidity (NOT converted to svJUSD)
+            // Note: JUICE is pre-approved to POSITION_MANAGER in constructor with max allowance
+            SafeERC20.safeTransferFrom(IERC20(address(JUICE)), msg.sender, address(this), amount);
+            return (address(JUICE), amount);
+        }
+
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[token];
+        if (address(config.bridge) != address(0)) {
+            // Bridged USD (e.g., USDC.e, USDT.e, ctUSD) → JUSD (via Bridge) → svJUSD
+            SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), amount);
+            config.bridge.mint(amount);
+            uint256 jusdAmount = _bridgedToJusdAmount(amount, config.decimals);
+            uint256 shares = SV_JUSD.deposit(jusdAmount, address(this));
+            return (address(SV_JUSD), shares);
+        } else {
+            // Other tokens - direct transfer
+            SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), amount);
             if (IERC20(token).allowance(address(this), address(POSITION_MANAGER)) < amount) {
                 SafeERC20.forceApprove(IERC20(token), address(POSITION_MANAGER), type(uint256).max);
             }
@@ -730,7 +894,46 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     }
 
     /**
-     * @dev Returns the actual token address used in pools
+     * @dev Handles output token conversion for liquidity operations
+     * @notice Unlike _handleTokenOut, JUICE is transferred directly (not converted from svJUSD)
+     */
+    function _handleTokenOutForLiquidity(
+        address token,
+        uint256 actualAmount,
+        address to
+    ) internal returns (uint256 userAmount) {
+        if (token == NATIVE_TOKEN) {
+            // WcBTC → Native cBTC
+            WCBTC.withdraw(actualAmount);
+            (bool success, ) = to.call{value: actualAmount}("");
+            if (!success) revert TransferFailed();
+            return actualAmount;
+        } else if (token == address(JUSD)) {
+            // svJUSD → JUSD
+            uint256 jusdAmount = SV_JUSD.redeem(actualAmount, to, address(this));
+            return jusdAmount;
+        } else if (token == address(JUICE)) {
+            // JUICE stays JUICE for liquidity - transfer directly
+            SafeERC20.safeTransfer(IERC20(address(JUICE)), to, actualAmount);
+            return actualAmount;
+        }
+
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[token];
+        if (address(config.bridge) != address(0)) {
+            // svJUSD → JUSD → Bridged USD (e.g., USDC.e, USDT.e, ctUSD)
+            uint256 jusdAmount = SV_JUSD.redeem(actualAmount, address(this), address(this));
+            config.bridge.burnAndSend(to, jusdAmount);
+            return _jusdToBridgedAmount(jusdAmount, config.decimals);
+        } else {
+            // Other tokens - direct transfer
+            SafeERC20.safeTransfer(IERC20(token), to, actualAmount);
+            return actualAmount;
+        }
+    }
+
+    /**
+     * @dev Returns the actual token address used in pools (for swaps)
      */
     function _getActualToken(address token) internal view returns (address) {
         if (token == NATIVE_TOKEN) return address(WCBTC);
@@ -739,6 +942,78 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Check if token is a bridged stablecoin
         if (address(bridgeConfigs[token].bridge) != address(0)) return address(SV_JUSD);
         return token;
+    }
+
+    /**
+     * @dev Returns the actual token address used in pools (for liquidity)
+     * @notice Unlike _getActualToken, JUICE stays as JUICE for liquidity operations
+     */
+    function _getActualTokenForLiquidity(address token) internal view returns (address) {
+        if (token == NATIVE_TOKEN) return address(WCBTC);
+        if (token == address(JUSD)) return address(SV_JUSD);
+        if (token == address(JUICE)) return address(JUICE); // JUICE stays JUICE for liquidity
+        // Check if token is a bridged stablecoin
+        if (address(bridgeConfigs[token].bridge) != address(0)) return address(SV_JUSD);
+        return token;
+    }
+
+    /**
+     * @dev Checks if a token is a USD-based token (JUSD or bridged stablecoin)
+     */
+    function _isUsdToken(address token) internal view returns (bool) {
+        if (token == address(JUSD)) return true;
+        if (address(bridgeConfigs[token].bridge) != address(0)) return true;
+        return false;
+    }
+
+    /**
+     * @dev Handles direct USD-to-USD conversions without svJUSD roundtrip
+     * @notice This is an optimization for JUSD <-> Bridged and JUSD/Bridged -> JUICE swaps.
+     *         Instead of: Input -> svJUSD -> JUSD -> Output
+     *         We do:      Input -> JUSD -> Output (skipping vault deposit/redeem)
+     * @param tokenIn The input token (JUSD or bridged stablecoin)
+     * @param tokenOut The output token (JUSD, bridged stablecoin, or JUICE)
+     * @param amountIn The input amount in tokenIn decimals
+     * @param to The recipient address
+     * @return amountOut The output amount in tokenOut decimals
+     */
+    function _handleDirectUsdConversion(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        address to
+    ) internal returns (uint256 amountOut) {
+        uint256 jusdAmount;
+
+        // Step 1: Convert input to JUSD (if not already JUSD)
+        if (tokenIn == address(JUSD)) {
+            SafeERC20.safeTransferFrom(JUSD, msg.sender, address(this), amountIn);
+            jusdAmount = amountIn;
+        } else {
+            // Bridged token input -> mint JUSD via bridge
+            BridgeConfig storage configIn = bridgeConfigs[tokenIn];
+            SafeERC20.safeTransferFrom(IERC20(tokenIn), msg.sender, address(this), amountIn);
+            configIn.bridge.mint(amountIn);
+            jusdAmount = _bridgedToJusdAmount(amountIn, configIn.decimals);
+        }
+
+        // Step 2: Convert JUSD to output token
+        if (tokenOut == address(JUSD)) {
+            SafeERC20.safeTransfer(JUSD, to, jusdAmount);
+            return jusdAmount;
+        } else if (tokenOut == address(JUICE)) {
+            // JUSD -> JUICE via Equity.invest()
+            // Note: JUSD already approved to JUICE in constructor
+            uint256 juiceAmount = JUICE.invest(jusdAmount, 0);
+            SafeERC20.safeTransfer(IERC20(address(JUICE)), to, juiceAmount);
+            return juiceAmount;
+        } else {
+            // JUSD -> Bridged token via bridge.burnAndSend()
+            // Note: JUSD already approved to bridge in registerBridgedToken()
+            BridgeConfig storage configOut = bridgeConfigs[tokenOut];
+            configOut.bridge.burnAndSend(to, jusdAmount);
+            return _jusdToBridgedAmount(jusdAmount, configOut.decimals);
+        }
     }
 
     /**
@@ -817,6 +1092,11 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         if (userToken == address(JUSD)) {
             return _jusdToSvJusdAmount(minAmount);
         }
+        if (userToken == address(JUICE)) {
+            // Convert JUICE amount to JUSD equivalent, then to svJUSD
+            uint256 jusdEquivalent = JUICE.calculateProceeds(minAmount);
+            return _jusdToSvJusdAmount(jusdEquivalent);
+        }
         // Check if token is a bridged stablecoin
         BridgeConfig storage config = bridgeConfigs[userToken];
         if (address(config.bridge) != address(0)) {
@@ -826,11 +1106,57 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
     }
 
     /**
-     * @dev Converts actual token amount back to user-facing token amount
+     * @dev Converts user-facing min amount to actual token min amount for liquidity operations
+     * @notice Unlike _toActualMinAmount, JUICE stays as JUICE (no conversion)
+     */
+    function _toActualMinAmountForLiquidity(address userToken, uint256 minAmount) internal view returns (uint256) {
+        if (userToken == address(JUSD)) {
+            return _jusdToSvJusdAmount(minAmount);
+        }
+        if (userToken == address(JUICE)) {
+            // JUICE stays JUICE for liquidity - no conversion needed
+            return minAmount;
+        }
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[userToken];
+        if (address(config.bridge) != address(0)) {
+            return _bridgedToSvJusdAmount(minAmount, config.decimals);
+        }
+        return minAmount;
+    }
+
+    /**
+     * @dev Converts actual token amount back to user-facing token amount (for swaps)
      */
     function _toUserAmount(address userToken, uint256 actualAmount) internal view returns (uint256) {
         if (userToken == address(JUSD)) {
             return _svJusdToJusdAmount(actualAmount);
+        }
+        if (userToken == address(JUICE)) {
+            // Convert svJUSD to JUSD equivalent, then estimate JUICE
+            uint256 jusdAmount = _svJusdToJusdAmount(actualAmount);
+            return JUICE.calculateShares(jusdAmount);
+        }
+        // Check if token is a bridged stablecoin
+        BridgeConfig storage config = bridgeConfigs[userToken];
+        if (address(config.bridge) != address(0)) {
+            uint256 jusdAmount = _svJusdToJusdAmount(actualAmount);
+            return _jusdToBridgedAmount(jusdAmount, config.decimals);
+        }
+        return actualAmount;
+    }
+
+    /**
+     * @dev Converts actual token amount back to user-facing token amount (for liquidity)
+     * @notice Unlike _toUserAmount, JUICE stays as JUICE (no conversion needed)
+     */
+    function _toUserAmountForLiquidity(address userToken, uint256 actualAmount) internal view returns (uint256) {
+        if (userToken == address(JUSD)) {
+            return _svJusdToJusdAmount(actualAmount);
+        }
+        if (userToken == address(JUICE)) {
+            // JUICE stays JUICE for liquidity - no conversion needed
+            return actualAmount;
         }
         // Check if token is a bridged stablecoin
         BridgeConfig storage config = bridgeConfigs[userToken];
@@ -848,13 +1174,32 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         int24 tickSpacing = FACTORY.feeAmountTickSpacing(fee);
         if (tickSpacing == 0) revert InvalidFee(fee);
 
-        int24 MIN_TICK = -887272;
-        int24 MAX_TICK = 887272;
-
         tickLower = (MIN_TICK / tickSpacing) * tickSpacing;
         tickUpper = (MAX_TICK / tickSpacing) * tickSpacing;
 
         return (tickLower, tickUpper);
+    }
+
+    /**
+     * @dev Validates custom tick range for concentrated liquidity positions
+     * @param tickLower The lower bound of the position's tick range
+     * @param tickUpper The upper bound of the position's tick range
+     * @param fee The fee tier to determine tick spacing
+     */
+    function _validateTicks(int24 tickLower, int24 tickUpper, uint24 fee) internal view {
+        if (tickLower >= tickUpper) revert InvalidTickRange(tickLower, tickUpper);
+
+        int24 tickSpacing = FACTORY.feeAmountTickSpacing(fee);
+        if (tickSpacing == 0) revert InvalidFee(fee);
+
+        // Ticks must be aligned to tickSpacing
+        if (tickLower % tickSpacing != 0) revert InvalidTickRange(tickLower, tickUpper);
+        if (tickUpper % tickSpacing != 0) revert InvalidTickRange(tickLower, tickUpper);
+
+        // Ticks must be within valid range
+        if (tickLower < MIN_TICK || tickUpper > MAX_TICK) {
+            revert InvalidTickRange(tickLower, tickUpper);
+        }
     }
 
     /**
@@ -871,6 +1216,9 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
             WCBTC.withdraw(excessAmount);
             (bool success, ) = to.call{value: excessAmount}("");
             if (!success) revert TransferFailed();
+        } else if (userToken == address(JUICE) && actualToken == address(JUICE)) {
+            // JUICE liquidity: return excess JUICE directly
+            SafeERC20.safeTransfer(IERC20(address(JUICE)), to, excessAmount);
         } else if (actualToken == address(SV_JUSD)) {
             // Check if userToken is a bridged stablecoin
             BridgeConfig storage config = bridgeConfigs[userToken];
@@ -878,10 +1226,11 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
                 // Convert excess svJUSD back to bridged USD via JUSD
                 uint256 jusdAmount = SV_JUSD.redeem(excessAmount, address(this), address(this));
                 config.bridge.burnAndSend(to, jusdAmount);
+            } else if (userToken == address(JUICE)) {
+                // JUICE swap input: return excess as JUSD (can't convert back to JUICE due to flash loan protection)
+                SV_JUSD.redeem(excessAmount, to, address(this));
             } else {
-                // Unreachable: if actualToken is svJUSD, userToken must be JUSD (handled above)
-                // or a bridged token (handled in if-branch). JUICE maps to svJUSD but cannot
-                // be used as input (JuiceInputNotSupported), so this branch is never reached.
+                // Unreachable: if actualToken is svJUSD, userToken must be JUSD, bridged token, or JUICE
                 revert InvalidToken();
             }
         } else if (actualToken != address(0)) {
@@ -890,45 +1239,124 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         }
     }
 
-    // ==================== Admin Functions ====================
-
     /**
-     * @notice Updates the default fee tier for swaps
-     * @param newFee The new fee tier (500 = 0.05%, 3000 = 0.3%, 10000 = 1%)
+     * @dev Babylonian square root implementation
      */
-    function setDefaultFee(uint24 newFee) external onlyOwner {
-        if (newFee >= 1_000_000) revert InvalidFee(newFee);
-        // Verify fee tier is enabled in factory (JUICE1-7 fix)
-        int24 tickSpacing = FACTORY.feeAmountTickSpacing(newFee);
-        if (tickSpacing == 0) revert InvalidFee(newFee);
-
-        uint24 oldFee = defaultFee;
-        defaultFee = newFee;
-        emit DefaultFeeUpdated(oldFee, newFee);
+    function _sqrt(uint256 x) internal pure returns (uint256 y) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
     }
 
     /**
-     * @notice Adds a bridged stablecoin that can be converted to JUSD via its bridge
-     * @param token The bridged stablecoin address (e.g., USDC.e, USDT.e, ctUSD)
+     * @dev Multiplies sqrtPriceX96 by sqrt(factor/1e18) for price conversion
+     * @notice Used when token0 is JUSD-based and converts to svJUSD
+     */
+    function _mulSqrtPrice(uint160 sqrtPriceX96, uint256 factor) internal pure returns (uint160) {
+        // We need to compute: sqrtPriceX96 * sqrt(factor / 1e18)
+        // = sqrtPriceX96 * sqrt(factor) / sqrt(1e18)
+        // = sqrtPriceX96 * sqrt(factor) / 1e9
+        uint256 sqrtFactor = _sqrt(factor);
+        uint256 result = (uint256(sqrtPriceX96) * sqrtFactor) / 1e9;
+        if (result > type(uint160).max) revert InvalidPrice();
+        return uint160(result);
+    }
+
+    /**
+     * @dev Divides sqrtPriceX96 by sqrt(factor/1e18) for price conversion
+     * @notice Used when token1 is JUSD-based and converts to svJUSD
+     */
+    function _divSqrtPrice(uint160 sqrtPriceX96, uint256 factor) internal pure returns (uint160) {
+        // We need to compute: sqrtPriceX96 / sqrt(factor / 1e18)
+        // = sqrtPriceX96 * sqrt(1e18) / sqrt(factor)
+        // = sqrtPriceX96 * 1e9 / sqrt(factor)
+        uint256 sqrtFactor = _sqrt(factor);
+        if (sqrtFactor == 0) revert InvalidPrice();
+        uint256 result = (uint256(sqrtPriceX96) * 1e9) / sqrtFactor;
+        if (result > type(uint160).max) revert InvalidPrice();
+        return uint160(result);
+    }
+
+    /**
+     * @dev Converts user-facing sqrtPriceX96 to actual pool sqrtPriceX96
+     * @notice Handles the svJUSD/JUSD share price ratio for price adjustment
+     *         sqrtPriceX96 = sqrt(token1/token0) * 2^96
+     *         When token0 converts to svJUSD: price increases (multiply by sqrt(sharePrice))
+     *         When token1 converts to svJUSD: price decreases (divide by sqrt(sharePrice))
+     */
+    function _convertSqrtPrice(
+        address userTokenA,
+        address userTokenB,
+        uint160 sqrtPriceX96
+    ) internal view returns (uint160) {
+        address actualTokenA = _getActualTokenForLiquidity(userTokenA);
+        address actualTokenB = _getActualTokenForLiquidity(userTokenB);
+
+        // Determine token ordering (Uniswap requires token0 < token1)
+        bool isAToken0 = actualTokenA < actualTokenB;
+        address userToken0 = isAToken0 ? userTokenA : userTokenB;
+        address userToken1 = isAToken0 ? userTokenB : userTokenA;
+
+        bool token0Converts = _isUsdToken(userToken0);
+        bool token1Converts = _isUsdToken(userToken1);
+
+        // No conversion needed if neither token is JUSD-based
+        if (!token0Converts && !token1Converts) {
+            return sqrtPriceX96;
+        }
+
+        // Both tokens converting to svJUSD is invalid (would be same token)
+        if (token0Converts && token1Converts) {
+            revert InvalidTokenPair(userTokenA, userTokenB);
+        }
+
+        // sharePrice = JUSD per svJUSD (e.g., 1.05e18 means 1 svJUSD = 1.05 JUSD)
+        uint256 sharePrice = SV_JUSD.convertToAssets(1e18);
+
+        if (token0Converts) {
+            // token0 is JUSD-based → becomes more valuable in svJUSD terms → price increases
+            return _mulSqrtPrice(sqrtPriceX96, sharePrice);
+        } else {
+            // token1 is JUSD-based → becomes more valuable in svJUSD terms → price decreases
+            return _divSqrtPrice(sqrtPriceX96, sharePrice);
+        }
+    }
+
+    // ==================== Bridge Registration (Permissionless) ====================
+
+    /**
+     * @notice Registers a bridged stablecoin that can be converted to JUSD via its bridge
+     * @dev Permissionless - anyone can register a bridge IF it's an approved JUSD minter.
+     *      The security comes from JUSD governance: bridges must go through the veto period
+     *      before they can mint JUSD, so only governance-approved bridges can be registered.
+     *      The bridged token address is derived from bridge.usd().
      * @param bridge The StablecoinBridge contract for this token
      */
-    function addBridgedToken(address token, address bridge) external onlyOwner {
-        if (token == address(0) || bridge == address(0)) revert InvalidBridgeConfig();
-        if (bridgedTokens.length >= MAX_BRIDGED_TOKENS) revert TooManyBridgedTokens();
+    function registerBridgedToken(address bridge) external {
+        if (bridge == address(0)) revert InvalidBridgeConfig();
+
+        IStablecoinBridge bridgeContract = IStablecoinBridge(bridge);
+        address token = bridgeContract.usd();
+
+        if (token == address(0)) revert InvalidBridgeConfig();
         if (bridgeConfigs[token].bridge != IStablecoinBridge(address(0))) {
             revert BridgedTokenAlreadyExists(token);
         }
-
-        // Validate bridge configuration matches expected tokens
-        IStablecoinBridge bridgeContract = IStablecoinBridge(bridge);
-        if (bridgeContract.usd() != token) revert InvalidBridgeConfig();
         if (bridgeContract.JUSD() != address(JUSD)) revert InvalidBridgeConfig();
 
+        // Critical: Bridge must be approved JUSD minter (via JUSD governance veto system)
+        // This ensures only governance-approved bridges can be registered
+        if (!IJuiceDollar(address(JUSD)).isMinter(bridge)) revert BridgeNotApprovedMinter(bridge);
+
+        // Check if bridge is stopped (emergency governance action)
+        if (bridgeContract.stopped()) revert BridgeStopped(bridge);
+
         uint8 decimals = IERC20Metadata(token).decimals();
-        bridgeConfigs[token] = BridgeConfig({
-            bridge: IStablecoinBridge(bridge),
-            decimals: decimals
-        });
+        bridgeConfigs[token] = BridgeConfig({bridge: IStablecoinBridge(bridge), decimals: decimals});
         bridgedTokens.push(token);
 
         // Approve bridged token to bridge for mint operations
@@ -936,38 +1364,7 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         // Approve JUSD to bridge for burn operations
         JUSD.approve(bridge, type(uint256).max);
 
-        emit BridgedTokenAdded(token, bridge, decimals);
-    }
-
-    /**
-     * @notice Removes a bridged stablecoin from the supported list
-     * @param token The bridged stablecoin address to remove
-     */
-    function removeBridgedToken(address token) external onlyOwner {
-        if (bridgeConfigs[token].bridge == IStablecoinBridge(address(0))) {
-            revert BridgedTokenNotFound(token);
-        }
-
-        address bridge = address(bridgeConfigs[token].bridge);
-
-        // Remove from mapping
-        delete bridgeConfigs[token];
-
-        // Remove from array (swap with last element and pop)
-        uint256 length = bridgedTokens.length;
-        for (uint256 i = 0; i < length; i++) {
-            if (bridgedTokens[i] == token) {
-                bridgedTokens[i] = bridgedTokens[length - 1];
-                bridgedTokens.pop();
-                break;
-            }
-        }
-
-        // Revoke approvals
-        IERC20(token).approve(bridge, 0);
-        JUSD.approve(bridge, 0);
-
-        emit BridgedTokenRemoved(token);
+        emit BridgedTokenRegistered(token, bridge, msg.sender, decimals);
     }
 
     /**
@@ -977,39 +1374,194 @@ contract JuiceSwapGateway is IJuiceSwapGateway, Ownable, ReentrancyGuard, Pausab
         return bridgedTokens;
     }
 
+    // ==================== Pool Creation ====================
+
     /**
-     * @notice Rescue function to withdraw accidentally sent native cBTC
+     * @notice View function to check if a pool exists for a token pair
+     * @dev Converts user tokens to actual pool tokens before checking
      */
-    function rescueNative() external onlyOwner {
-        uint256 balance = address(this).balance;
-        if (balance > 0) {
-            (bool success, ) = owner().call{value: balance}("");
-            if (!success) revert TransferFailed();
-            emit NativeRescued(owner(), balance);
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool, bool exists) {
+        address actualTokenA = _getActualTokenForLiquidity(tokenA);
+        address actualTokenB = _getActualTokenForLiquidity(tokenB);
+        uint24 effectiveFee = fee == 0 ? DEFAULT_FEE : fee;
+
+        pool = FACTORY.getPool(actualTokenA, actualTokenB, effectiveFee);
+        exists = pool != address(0);
+    }
+
+    /**
+     * @notice Creates and initializes a new pool if it doesn't exist
+     * @dev Converts user-facing tokens to actual pool tokens and adjusts price accordingly
+     */
+    function createPool(
+        address tokenA,
+        address tokenB,
+        uint24 fee,
+        uint160 sqrtPriceX96
+    ) external nonReentrant returns (address pool) {
+        // Validate tokens
+        if (tokenA == tokenB) revert InvalidTokenPair(tokenA, tokenB);
+
+        // JUICE restriction for liquidity pools
+        if (tokenA == address(JUICE) || tokenB == address(JUICE)) {
+            address otherToken = tokenA == address(JUICE) ? tokenB : tokenA;
+            if (_isUsdToken(otherToken) || otherToken == address(SV_JUSD)) {
+                revert JuiceCannotPairWithUsd(otherToken);
+            }
         }
+
+        // Prevent redundant pools (both tokens map to svJUSD)
+        address actualTokenA = _getActualTokenForLiquidity(tokenA);
+        address actualTokenB = _getActualTokenForLiquidity(tokenB);
+        if (actualTokenA == actualTokenB) {
+            revert InvalidTokenPair(tokenA, tokenB);
+        }
+
+        // Use default fee if 0
+        uint24 effectiveFee = fee == 0 ? DEFAULT_FEE : fee;
+        if (effectiveFee >= 1_000_000) revert InvalidFee(effectiveFee);
+
+        // Ensure token ordering (token0 < token1)
+        (address token0, address token1) = actualTokenA < actualTokenB
+            ? (actualTokenA, actualTokenB)
+            : (actualTokenB, actualTokenA);
+
+        // Convert price if needed
+        uint160 actualSqrtPriceX96 = _convertSqrtPrice(tokenA, tokenB, sqrtPriceX96);
+        if (actualSqrtPriceX96 == 0) revert InvalidPrice();
+
+        // Create and initialize pool
+        pool = POSITION_MANAGER.createAndInitializePoolIfNecessary(token0, token1, effectiveFee, actualSqrtPriceX96);
+
+        emit PoolCreated(msg.sender, tokenA, tokenB, token0, token1, effectiveFee, pool);
+
+        return pool;
     }
 
     /**
-     * @notice Rescue function to withdraw accidentally sent tokens
+     * @notice Creates a pool and adds initial liquidity in a single transaction
+     * @dev Combines createPool() and addLiquidity() for gas efficiency
      */
-    function rescueToken(address token, address to, uint256 amount) external onlyOwner {
-        if (to == address(0)) revert InvalidToken();
-        SafeERC20.safeTransfer(IERC20(token), to, amount);
-        emit TokenRescued(token, to, amount);
-    }
+    function createPoolAndAddLiquidity(
+        address tokenA,
+        address tokenB,
+        uint24 fee,
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external payable nonReentrant returns (address pool, uint256 amountA, uint256 amountB, uint256 liquidity) {
+        if (block.timestamp > deadline) revert DeadlineExpired();
 
-    /**
-     * @notice Pause the contract
-     */
-    function pause() external onlyOwner {
-        _pause();
-    }
+        // Validate tokens
+        if (tokenA == tokenB) revert InvalidTokenPair(tokenA, tokenB);
 
-    /**
-     * @notice Unpause the contract
-     */
-    function unpause() external onlyOwner {
-        _unpause();
+        // JUICE liquidity restriction
+        if (tokenA == address(JUICE) || tokenB == address(JUICE)) {
+            address otherToken = tokenA == address(JUICE) ? tokenB : tokenA;
+            if (_isUsdToken(otherToken) || otherToken == address(SV_JUSD)) {
+                revert JuiceCannotPairWithUsd(otherToken);
+            }
+        }
+
+        // Get actual tokens and validate
+        address actualTokenA = _getActualTokenForLiquidity(tokenA);
+        address actualTokenB = _getActualTokenForLiquidity(tokenB);
+        if (actualTokenA == actualTokenB) {
+            revert InvalidTokenPair(tokenA, tokenB);
+        }
+
+        // Use default fee if 0
+        uint24 effectiveFee = fee == 0 ? DEFAULT_FEE : fee;
+        if (effectiveFee >= 1_000_000) revert InvalidFee(effectiveFee);
+
+        // Token ordering
+        bool isAToken0 = actualTokenA < actualTokenB;
+        (address token0, address token1) = isAToken0 ? (actualTokenA, actualTokenB) : (actualTokenB, actualTokenA);
+
+        // Create pool if necessary
+        uint160 actualSqrtPriceX96 = _convertSqrtPrice(tokenA, tokenB, sqrtPriceX96);
+        if (actualSqrtPriceX96 == 0) revert InvalidPrice();
+
+        pool = POSITION_MANAGER.createAndInitializePoolIfNecessary(token0, token1, effectiveFee, actualSqrtPriceX96);
+
+        emit PoolCreated(msg.sender, tokenA, tokenB, token0, token1, effectiveFee, pool);
+
+        // Convert input tokens
+        (, uint256 actualAmountADesired) = _handleTokenInForLiquidity(tokenA, amountADesired);
+        (, uint256 actualAmountBDesired) = _handleTokenInForLiquidity(tokenB, amountBDesired);
+
+        // Calculate minimums
+        uint256 actualAmountAMin = _toActualMinAmountForLiquidity(tokenA, amountAMin);
+        uint256 actualAmountBMin = _toActualMinAmountForLiquidity(tokenB, amountBMin);
+
+        (uint256 amount0Desired, uint256 amount1Desired) = isAToken0
+            ? (actualAmountADesired, actualAmountBDesired)
+            : (actualAmountBDesired, actualAmountADesired);
+
+        (uint256 amount0Min, uint256 amount1Min) = isAToken0
+            ? (actualAmountAMin, actualAmountBMin)
+            : (actualAmountBMin, actualAmountAMin);
+
+        // Tick range
+        int24 actualTickLower;
+        int24 actualTickUpper;
+        if (tickLower == tickUpper) {
+            (actualTickLower, actualTickUpper) = _getFullRangeTicks(effectiveFee);
+        } else {
+            _validateTicks(tickLower, tickUpper, effectiveFee);
+            actualTickLower = tickLower;
+            actualTickUpper = tickUpper;
+        }
+
+        // Mint position
+        INonfungiblePositionManager.MintParams memory params = INonfungiblePositionManager.MintParams({
+            token0: token0,
+            token1: token1,
+            fee: effectiveFee,
+            tickLower: actualTickLower,
+            tickUpper: actualTickUpper,
+            amount0Desired: amount0Desired,
+            amount1Desired: amount1Desired,
+            amount0Min: amount0Min,
+            amount1Min: amount1Min,
+            recipient: to,
+            deadline: deadline
+        });
+
+        (uint256 tokenId, , uint256 amount0, uint256 amount1) = POSITION_MANAGER.mint(params);
+
+        // Map back to A/B order (in pool token units)
+        (uint256 poolAmountA, uint256 poolAmountB) = isAToken0 ? (amount0, amount1) : (amount1, amount0);
+        liquidity = tokenId;
+
+        // Return excess tokens
+        uint256 excessA = isAToken0
+            ? (amount0Desired > amount0 ? amount0Desired - amount0 : 0)
+            : (amount1Desired > amount1 ? amount1Desired - amount1 : 0);
+        uint256 excessB = isAToken0
+            ? (amount1Desired > amount1 ? amount1Desired - amount1 : 0)
+            : (amount0Desired > amount0 ? amount0Desired - amount0 : 0);
+
+        _returnExcess(tokenA, actualTokenA, excessA, msg.sender);
+        _returnExcess(tokenB, actualTokenB, excessB, msg.sender);
+
+        // Convert to user-facing amounts for return values and event
+        amountA = _toUserAmountForLiquidity(tokenA, poolAmountA);
+        amountB = _toUserAmountForLiquidity(tokenB, poolAmountB);
+
+        // Verify final amounts meet user's minimums after all conversions
+        if (amountA < amountAMin) revert InsufficientOutput();
+        if (amountB < amountBMin) revert InsufficientOutput();
+
+        emit LiquidityAdded(msg.sender, tokenA, tokenB, amountA, amountB, tokenId);
+
+        return (pool, amountA, amountB, liquidity);
     }
 
     /**

--- a/contracts/interfaces/IJuiceSwapGateway.sol
+++ b/contracts/interfaces/IJuiceSwapGateway.sol
@@ -13,10 +13,10 @@ pragma solidity ^0.8.20;
 interface IJuiceSwapGateway {
     /// @notice Status information for a bridged stablecoin's bridge
     struct BridgeStatus {
-        bool canMint;           // Can deposit bridged token (mint JUSD)?
-        bool canBurn;           // Can withdraw to bridged token (burn JUSD)?
-        uint256 mintCapacity;   // Remaining JUSD that can be minted (in JUSD decimals)
-        uint256 burnCapacity;   // Available bridged token for burns (in bridged token decimals)
+        bool canMint; // Can deposit bridged token (mint JUSD)?
+        bool canBurn; // Can withdraw to bridged token (burn JUSD)?
+        uint256 mintCapacity; // Remaining JUSD that can be minted (in JUSD decimals)
+        uint256 burnCapacity; // Available bridged token for burns (in bridged token decimals)
         string mintBlockReason; // Reason why minting is blocked (empty if canMint)
         string burnBlockReason; // Reason why burning is blocked (empty if canBurn)
     }
@@ -89,6 +89,40 @@ interface IJuiceSwapGateway {
     );
 
     /**
+     * @notice Emitted when a bridged token is registered (permissionless)
+     * @param token The bridged stablecoin address
+     * @param bridge The StablecoinBridge contract address
+     * @param registeredBy The address that called registerBridgedToken
+     * @param decimals The token's decimals
+     */
+    event BridgedTokenRegistered(
+        address indexed token,
+        address indexed bridge,
+        address indexed registeredBy,
+        uint8 decimals
+    );
+
+    /**
+     * @notice Emitted when a new pool is created through the gateway
+     * @param creator The address that created the pool
+     * @param tokenA First user-facing token address
+     * @param tokenB Second user-facing token address
+     * @param actualToken0 Actual pool token0 (e.g., svJUSD instead of JUSD)
+     * @param actualToken1 Actual pool token1
+     * @param fee The pool fee tier
+     * @param pool The address of the created pool
+     */
+    event PoolCreated(
+        address indexed creator,
+        address indexed tokenA,
+        address indexed tokenB,
+        address actualToken0,
+        address actualToken1,
+        uint24 fee,
+        address pool
+    );
+
+    /**
      * @notice Swaps an exact amount of input tokens for as many output tokens as possible
      * @param tokenIn The address of the input token (use address(0) for native cBTC)
      * @param tokenOut The address of the output token (use address(0) for native cBTC)
@@ -110,10 +144,12 @@ interface IJuiceSwapGateway {
     ) external payable returns (uint256 amountOut);
 
     /**
-     * @notice Adds liquidity to a token pair pool
+     * @notice Adds liquidity to a token pair pool with optional custom tick range
      * @param tokenA The address of the first token (use address(0) for native cBTC)
      * @param tokenB The address of the second token
      * @param fee The Uniswap V3 fee tier (100 = 0.01%, 500 = 0.05%, 3000 = 0.3%, 10000 = 1%)
+     * @param tickLower The lower tick of the position range (if tickLower == tickUpper, uses full range)
+     * @param tickUpper The upper tick of the position range (if tickLower == tickUpper, uses full range)
      * @param amountADesired The desired amount of tokenA to add
      * @param amountBDesired The desired amount of tokenB to add
      * @param amountAMin The minimum amount of tokenA to add (slippage protection)
@@ -128,6 +164,8 @@ interface IJuiceSwapGateway {
         address tokenA,
         address tokenB,
         uint24 fee,
+        int24 tickLower,
+        int24 tickUpper,
         uint256 amountADesired,
         uint256 amountBDesired,
         uint256 amountAMin,
@@ -245,17 +283,13 @@ interface IJuiceSwapGateway {
     function getBridgedTokens() external view returns (address[] memory);
 
     /**
-     * @notice Adds a bridged stablecoin that can be converted to JUSD via its bridge
-     * @param token The bridged stablecoin address
+     * @notice Registers a bridged stablecoin that can be converted to JUSD via its bridge
+     * @dev Permissionless - anyone can register a bridge IF it's an approved JUSD minter.
+     *      The security comes from JUSD governance (veto system).
+     *      The bridged token address is derived from bridge.usd().
      * @param bridge The StablecoinBridge contract for this token
      */
-    function addBridgedToken(address token, address bridge) external;
-
-    /**
-     * @notice Removes a bridged stablecoin from the supported list
-     * @param token The bridged stablecoin address to remove
-     */
-    function removeBridgedToken(address token) external;
+    function registerBridgedToken(address bridge) external;
 
     /**
      * @notice Returns comprehensive status information for a bridged token's bridge
@@ -271,4 +305,68 @@ interface IJuiceSwapGateway {
      *         - burnBlockReason: Human-readable reason if burning blocked
      */
     function getBridgeStatus(address bridgedToken) external view returns (BridgeStatus memory status);
+
+    /**
+     * @notice Creates and initializes a new pool if it doesn't exist
+     * @dev Converts user-facing tokens to actual pool tokens (e.g., JUSD -> svJUSD)
+     *      and adjusts the price accordingly based on svJUSD share price.
+     * @param tokenA First user-facing token address (use address(0) for native cBTC)
+     * @param tokenB Second user-facing token address
+     * @param fee The pool fee tier (100, 500, 3000, or 10000). Use 0 for default (3000).
+     * @param sqrtPriceX96 Initial sqrt price in user-token terms (will be converted for actual tokens)
+     * @return pool The address of the created (or existing) pool
+     */
+    function createPool(
+        address tokenA,
+        address tokenB,
+        uint24 fee,
+        uint160 sqrtPriceX96
+    ) external returns (address pool);
+
+    /**
+     * @notice Creates a pool and adds initial liquidity in a single transaction
+     * @dev Combines createPool() and addLiquidity() for gas efficiency.
+     *      If pool already exists, only adds liquidity (sqrtPriceX96 is ignored).
+     * @param tokenA First user-facing token address (use address(0) for native cBTC)
+     * @param tokenB Second user-facing token address
+     * @param fee The pool fee tier. Use 0 for default (3000).
+     * @param sqrtPriceX96 Initial sqrt price in user-token terms (ignored if pool exists)
+     * @param tickLower Lower tick bound (use tickLower == tickUpper for full range)
+     * @param tickUpper Upper tick bound
+     * @param amountADesired Desired amount of tokenA
+     * @param amountBDesired Desired amount of tokenB
+     * @param amountAMin Minimum amount of tokenA (slippage protection)
+     * @param amountBMin Minimum amount of tokenB (slippage protection)
+     * @param to Recipient of the LP NFT
+     * @param deadline Transaction deadline
+     * @return pool The pool address
+     * @return amountA Actual amount of tokenA used
+     * @return amountB Actual amount of tokenB used
+     * @return liquidity The NFT token ID
+     */
+    function createPoolAndAddLiquidity(
+        address tokenA,
+        address tokenB,
+        uint24 fee,
+        uint160 sqrtPriceX96,
+        int24 tickLower,
+        int24 tickUpper,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external payable returns (address pool, uint256 amountA, uint256 amountB, uint256 liquidity);
+
+    /**
+     * @notice View function to check if a pool exists for a token pair
+     * @dev Converts user tokens to actual pool tokens before checking
+     * @param tokenA First user-facing token address (use address(0) for native cBTC)
+     * @param tokenB Second user-facing token address
+     * @param fee The pool fee tier. Use 0 for default (3000).
+     * @return pool The pool address (address(0) if doesn't exist)
+     * @return exists True if pool exists
+     */
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool, bool exists);
 }

--- a/contracts/interfaces/IStablecoinBridge.sol
+++ b/contracts/interfaces/IStablecoinBridge.sol
@@ -34,11 +34,6 @@ interface IStablecoinBridge {
     function burnAndSend(address target, uint256 amount) external;
 
     /**
-     * @notice Check if the bridge has been permanently stopped
-     */
-    function stopped() external view returns (bool);
-
-    /**
      * @notice The expiration timestamp after which minting is disabled
      */
     function horizon() external view returns (uint256);
@@ -62,4 +57,9 @@ interface IStablecoinBridge {
      * @notice The JUSD token
      */
     function JUSD() external view returns (address);
+
+    /**
+     * @notice Check if the bridge has been permanently stopped
+     */
+    function stopped() external view returns (bool);
 }

--- a/contracts/mocks/MaliciousERC20.sol
+++ b/contracts/mocks/MaliciousERC20.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IJuiceSwapGatewayReentrancy {
+    function swapExactTokensForTokens(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint24 fee,
+        int24 tickLower,
+        int24 tickUpper,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256 amountA, uint256 amountB, uint256 liquidity);
+}
+
+/**
+ * @title MaliciousERC20
+ * @notice ERC20 that attempts reentrancy during transfer/transferFrom callbacks
+ * @dev Used for testing ReentrancyGuard protection in JuiceSwapGateway
+ */
+contract MaliciousERC20 is ERC20 {
+    IJuiceSwapGatewayReentrancy public target;
+    address public tokenOut;
+    bool public attackOnTransfer;
+    bool public attackOnTransferFrom;
+    uint256 public attackCount;
+    bool private _attacking;
+
+    constructor() ERC20("Malicious Token", "EVIL") {}
+
+    function setTarget(address _target, address _tokenOut) external {
+        target = IJuiceSwapGatewayReentrancy(_target);
+        tokenOut = _tokenOut;
+    }
+
+    function enableAttackOnTransfer(bool _enabled) external {
+        attackOnTransfer = _enabled;
+    }
+
+    function enableAttackOnTransferFrom(bool _enabled) external {
+        attackOnTransferFrom = _enabled;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        if (attackOnTransfer && !_attacking && address(target) != address(0)) {
+            _attacking = true;
+            attackCount++;
+            // Attempt reentrant call to swap
+            try
+                target.swapExactTokensForTokens(
+                    address(this),
+                    tokenOut,
+                    3000,
+                    1 ether,
+                    0,
+                    msg.sender,
+                    block.timestamp + 3600
+                )
+            {} catch {}
+            _attacking = false;
+        }
+        return super.transfer(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        if (attackOnTransferFrom && !_attacking && address(target) != address(0)) {
+            _attacking = true;
+            attackCount++;
+            // Attempt reentrant call to swap
+            try
+                target.swapExactTokensForTokens(address(this), tokenOut, 3000, 1 ether, 0, from, block.timestamp + 3600)
+            {} catch {}
+            _attacking = false;
+        }
+        return super.transferFrom(from, to, amount);
+    }
+
+    function resetAttackCount() external {
+        attackCount = 0;
+    }
+}

--- a/contracts/mocks/MaliciousReceiver.sol
+++ b/contracts/mocks/MaliciousReceiver.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IJuiceSwapGatewayReentrancy {
+    function removeLiquidity(
+        uint256 tokenId,
+        uint128 liquidityToRemove,
+        address tokenA,
+        address tokenB,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256, uint256);
+
+    function swapExactTokensForTokens(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256);
+}
+
+/**
+ * @title MaliciousReceiver
+ * @notice Contract that attempts reentrancy when receiving native tokens
+ * @dev Used for testing ReentrancyGuard protection on removeLiquidity with native cBTC output
+ */
+contract MaliciousReceiver {
+    IJuiceSwapGatewayReentrancy public target;
+    uint256 public tokenId;
+    address public tokenA;
+    address public tokenB;
+    bool public attackEnabled;
+    uint256 public attackCount;
+    bool private _attacking;
+
+    enum AttackType {
+        REMOVE_LIQUIDITY,
+        SWAP
+    }
+    AttackType public attackType;
+
+    function setAttackRemoveLiquidity(address _target, uint256 _tokenId, address _tokenA, address _tokenB) external {
+        target = IJuiceSwapGatewayReentrancy(_target);
+        tokenId = _tokenId;
+        tokenA = _tokenA;
+        tokenB = _tokenB;
+        attackType = AttackType.REMOVE_LIQUIDITY;
+    }
+
+    function setAttackSwap(address _target, address _tokenA, address _tokenB) external {
+        target = IJuiceSwapGatewayReentrancy(_target);
+        tokenA = _tokenA;
+        tokenB = _tokenB;
+        attackType = AttackType.SWAP;
+    }
+
+    function enableAttack(bool _enabled) external {
+        attackEnabled = _enabled;
+    }
+
+    function resetAttackCount() external {
+        attackCount = 0;
+    }
+
+    receive() external payable {
+        if (attackEnabled && !_attacking && address(target) != address(0)) {
+            _attacking = true;
+            attackCount++;
+
+            if (attackType == AttackType.REMOVE_LIQUIDITY) {
+                try
+                    target.removeLiquidity(tokenId, 0, tokenA, tokenB, 0, 0, address(this), block.timestamp + 3600)
+                {} catch {}
+            } else {
+                try
+                    target.swapExactTokensForTokens{value: msg.value}(
+                        address(0), // Native token
+                        tokenB,
+                        3000,
+                        msg.value,
+                        0,
+                        address(this),
+                        block.timestamp + 3600
+                    )
+                {} catch {}
+            }
+
+            _attacking = false;
+        }
+    }
+
+    // Allow contract to hold tokens for testing
+    function withdraw() external {
+        payable(msg.sender).transfer(address(this).balance);
+    }
+}

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -6,6 +6,9 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract MockERC20 is ERC20 {
     uint8 private _decimals;
 
+    // For JUSD minter simulation (used by JuiceSwapGateway.registerBridgedToken)
+    mapping(address => bool) private _minters;
+
     constructor(
         string memory name,
         string memory symbol,
@@ -24,5 +27,14 @@ contract MockERC20 is ERC20 {
 
     function burn(address from, uint256 amount) external {
         _burn(from, amount);
+    }
+
+    // JUSD minter simulation
+    function setMinter(address minter, bool approved) external {
+        _minters[minter] = approved;
+    }
+
+    function isMinter(address minter) external view returns (bool) {
+        return _minters[minter];
     }
 }

--- a/contracts/mocks/MockEquity.sol
+++ b/contracts/mocks/MockEquity.sol
@@ -83,6 +83,28 @@ contract MockEquity is ERC20 {
     }
 
     /**
+     * @notice Redeem JUICE on behalf of owner
+     * @param owner Address whose JUICE to redeem
+     * @param target Address to send JUSD to
+     * @param shares Amount of JUICE to redeem
+     * @param expectedProceeds Minimum proceeds expected (ignored in mock)
+     * @return proceeds Amount of JUSD returned
+     */
+    function redeemFrom(address owner, address target, uint256 shares, uint256 expectedProceeds) external returns (uint256 proceeds) {
+        expectedProceeds; // Silence unused variable warning
+
+        // Transfer JUICE from owner to this contract (requires allowance)
+        transferFrom(owner, address(this), shares);
+        _burn(address(this), shares);
+
+        // Calculate proceeds: shares * PRICE
+        proceeds = (shares * PRICE) / 1e18;
+        JUSD.transfer(target, proceeds);
+
+        return proceeds;
+    }
+
+    /**
      * @notice Calculate JUSD received when redeeming JUICE
      * @param shares Amount of JUICE to redeem
      * @return proceeds Amount of JUSD that would be received

--- a/contracts/mocks/MockFactory.sol
+++ b/contracts/mocks/MockFactory.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 contract MockFactory {
     mapping(uint24 => int24) private _feeAmountTickSpacing;
+    mapping(bytes32 => address) private _pools;
 
     constructor() {
         _feeAmountTickSpacing[100] = 1;
@@ -17,5 +18,15 @@ contract MockFactory {
 
     function enableFeeAmount(uint24 fee, int24 tickSpacing) external {
         _feeAmountTickSpacing[fee] = tickSpacing;
+    }
+
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address) {
+        (address t0, address t1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        return _pools[keccak256(abi.encodePacked(t0, t1, fee))];
+    }
+
+    function setPool(address tokenA, address tokenB, uint24 fee, address pool) external {
+        (address t0, address t1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        _pools[keccak256(abi.encodePacked(t0, t1, fee))] = pool;
     }
 }

--- a/contracts/mocks/MockPositionManager.sol
+++ b/contracts/mocks/MockPositionManager.sol
@@ -51,6 +51,23 @@ contract MockPositionManager is ERC721 {
     uint256 private _mockIncreaseAmount0;
     uint256 private _mockIncreaseAmount1;
 
+    // Pool creation state
+    mapping(bytes32 => address) private _pools;
+    uint256 private _poolCounter = 1;
+    address private _nextPoolAddress;
+
+    // For testing NFT transfer failures
+    bool private _failNextSafeTransfer;
+    string private _safeTransferFailReason;
+
+    // For testing mint/increase/decrease failures
+    bool private _failNextMint;
+    string private _mintFailReason;
+    bool private _failNextIncrease;
+    string private _increaseFailReason;
+    bool private _failNextDecrease;
+    string private _decreaseFailReason;
+
     constructor() ERC721("Mock Position", "MPOS") {
         _factory = new MockFactory();
     }
@@ -62,11 +79,15 @@ contract MockPositionManager is ERC721 {
     /**
      * @notice Mock mint function
      */
-    function mint(MintParams calldata params)
-        external
-        payable
-        returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1)
-    {
+    function mint(
+        MintParams calldata params
+    ) external payable returns (uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) {
+        // Check for failure simulation
+        if (_failNextMint) {
+            _failNextMint = false;
+            revert(_mintFailReason);
+        }
+
         // Use preset values if available, otherwise calculate
         tokenId = _mockTokenId > 0 ? _mockTokenId : _nextTokenId++;
         liquidity = _mockLiquidity > 0 ? _mockLiquidity : 100;
@@ -117,15 +138,16 @@ contract MockPositionManager is ERC721 {
     /**
      * @notice Mock increaseLiquidity function
      */
-    function increaseLiquidity(IncreaseLiquidityParams calldata params)
-        external
-        payable
-        returns (uint128 liquidity, uint256 amount0, uint256 amount1)
-    {
-        require(
-            ownerOf(params.tokenId) == msg.sender || getApproved(params.tokenId) == msg.sender,
-            "Not authorized"
-        );
+    function increaseLiquidity(
+        IncreaseLiquidityParams calldata params
+    ) external payable returns (uint128 liquidity, uint256 amount0, uint256 amount1) {
+        // Check for failure simulation
+        if (_failNextIncrease) {
+            _failNextIncrease = false;
+            revert(_increaseFailReason);
+        }
+
+        require(ownerOf(params.tokenId) == msg.sender || getApproved(params.tokenId) == msg.sender, "Not authorized");
 
         // Use preset values if available, otherwise use desired amounts
         liquidity = _mockIncreaseLiquidity > 0 ? _mockIncreaseLiquidity : 100;
@@ -151,15 +173,16 @@ contract MockPositionManager is ERC721 {
     /**
      * @notice Mock decreaseLiquidity function
      */
-    function decreaseLiquidity(DecreaseLiquidityParams calldata params)
-        external
-        payable
-        returns (uint256 amount0, uint256 amount1)
-    {
-        require(
-            ownerOf(params.tokenId) == msg.sender || getApproved(params.tokenId) == msg.sender,
-            "Not authorized"
-        );
+    function decreaseLiquidity(
+        DecreaseLiquidityParams calldata params
+    ) external payable returns (uint256 amount0, uint256 amount1) {
+        // Check for failure simulation
+        if (_failNextDecrease) {
+            _failNextDecrease = false;
+            revert(_decreaseFailReason);
+        }
+
+        require(ownerOf(params.tokenId) == msg.sender || getApproved(params.tokenId) == msg.sender, "Not authorized");
 
         Position storage pos = _positions[params.tokenId];
         require(pos.liquidity >= params.liquidity, "Insufficient liquidity");
@@ -182,15 +205,8 @@ contract MockPositionManager is ERC721 {
     /**
      * @notice Mock collect function
      */
-    function collect(CollectParams calldata params)
-        external
-        payable
-        returns (uint256 amount0, uint256 amount1)
-    {
-        require(
-            ownerOf(params.tokenId) == msg.sender || getApproved(params.tokenId) == msg.sender,
-            "Not authorized"
-        );
+    function collect(CollectParams calldata params) external payable returns (uint256 amount0, uint256 amount1) {
+        require(ownerOf(params.tokenId) == msg.sender || getApproved(params.tokenId) == msg.sender, "Not authorized");
 
         Position storage pos = _positions[params.tokenId];
 
@@ -216,7 +232,9 @@ contract MockPositionManager is ERC721 {
     /**
      * @notice Get position data (mimics Uniswap V3)
      */
-    function positions(uint256 tokenId)
+    function positions(
+        uint256 tokenId
+    )
         external
         view
         returns (
@@ -247,18 +265,13 @@ contract MockPositionManager is ERC721 {
             0, // feeGrowthInside0LastX128
             0, // feeGrowthInside1LastX128
             0, // tokensOwed0
-            0  // tokensOwed1
+            0 // tokensOwed1
         );
     }
 
     // ========== Test Helpers ==========
 
-    function setMintResult(
-        uint256 tokenId,
-        uint128 liquidity,
-        uint256 amount0,
-        uint256 amount1
-    ) external {
+    function setMintResult(uint256 tokenId, uint128 liquidity, uint256 amount0, uint256 amount1) external {
         _mockTokenId = tokenId;
         _mockLiquidity = liquidity;
         _mockAmount0 = amount0;
@@ -276,12 +289,7 @@ contract MockPositionManager is ERC721 {
         _mockIncreaseAmount1 = amount1;
     }
 
-    function setPositionData(
-        uint256 tokenId,
-        address token0,
-        address token1,
-        uint128 liquidity
-    ) external {
+    function setPositionData(uint256 tokenId, address token0, address token1, uint128 liquidity) external {
         _positions[tokenId] = Position({
             token0: token0,
             token1: token1,
@@ -294,6 +302,123 @@ contract MockPositionManager is ERC721 {
 
     function mintNFT(address to, uint256 tokenId) external {
         _mint(to, tokenId);
+    }
+
+    // ========== Pool Creation ==========
+
+    /**
+     * @notice Mock createAndInitializePoolIfNecessary
+     */
+    function createAndInitializePoolIfNecessary(
+        address token0,
+        address token1,
+        uint24 fee,
+        uint160 /* sqrtPriceX96 */
+    ) external payable returns (address pool) {
+        // Use preset mock address if set
+        if (_nextPoolAddress != address(0)) {
+            pool = _nextPoolAddress;
+            _nextPoolAddress = address(0);
+            return pool;
+        }
+
+        // Check if pool exists
+        bytes32 key = keccak256(abi.encodePacked(token0, token1, fee));
+        pool = _pools[key];
+
+        if (pool == address(0)) {
+            // Create new mock pool address
+            pool = address(uint160(0x1000 + _poolCounter++));
+            _pools[key] = pool;
+        }
+
+        return pool;
+    }
+
+    /**
+     * @notice Get pool address for a token pair
+     */
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address) {
+        (address t0, address t1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        return _pools[keccak256(abi.encodePacked(t0, t1, fee))];
+    }
+
+    /**
+     * @notice Test helper to preset the next pool address
+     */
+    function setNextPoolAddress(address pool) external {
+        _nextPoolAddress = pool;
+    }
+
+    /**
+     * @notice Test helper to set a pool for a token pair
+     */
+    function setPool(address tokenA, address tokenB, uint24 fee, address pool) external {
+        (address t0, address t1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        _pools[keccak256(abi.encodePacked(t0, t1, fee))] = pool;
+    }
+
+    // ========== NFT Transfer Failure Simulation ==========
+
+    /**
+     * @notice Test helper to simulate NFT transfer failure
+     * @param fail Whether the next safeTransferFrom should fail
+     * @param reason The revert reason if fail is true
+     */
+    function setFailSafeTransfer(bool fail, string calldata reason) external {
+        _failNextSafeTransfer = fail;
+        _safeTransferFailReason = reason;
+    }
+
+    /**
+     * @notice Override safeTransferFrom to allow failure simulation
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public virtual override {
+        if (_failNextSafeTransfer) {
+            _failNextSafeTransfer = false;
+            revert(_safeTransferFailReason);
+        }
+        super.safeTransferFrom(from, to, tokenId, data);
+    }
+
+    /**
+     * @notice Test helper to burn an NFT (for testing non-existent token scenarios)
+     */
+    function burnNFT(uint256 tokenId) external {
+        _burn(tokenId);
+    }
+
+    /**
+     * @notice Test helper to get position liquidity directly
+     */
+    function getPositionLiquidity(uint256 tokenId) external view returns (uint128) {
+        return _positions[tokenId].liquidity;
+    }
+
+    // ========== Mint/Increase/Decrease Failure Simulation ==========
+
+    /**
+     * @notice Test helper to simulate mint failure
+     */
+    function setFailNextMint(bool fail, string calldata reason) external {
+        _failNextMint = fail;
+        _mintFailReason = reason;
+    }
+
+    /**
+     * @notice Test helper to simulate increaseLiquidity failure
+     */
+    function setFailNextIncrease(bool fail, string calldata reason) external {
+        _failNextIncrease = fail;
+        _increaseFailReason = reason;
+    }
+
+    /**
+     * @notice Test helper to simulate decreaseLiquidity failure
+     */
+    function setFailNextDecrease(bool fail, string calldata reason) external {
+        _failNextDecrease = fail;
+        _decreaseFailReason = reason;
     }
 
     receive() external payable {}

--- a/contracts/mocks/MockStablecoinBridge.sol
+++ b/contracts/mocks/MockStablecoinBridge.sol
@@ -28,9 +28,9 @@ contract MockStablecoinBridge {
     uint256 public minted;
     bool public stopped;
 
-    error Stopped();
     error Expired();
     error LimitExceeded();
+    error Stopped();
 
     constructor(address _usd, address _jusd, uint256 _limit, uint256 _weeks) {
         usd = IERC20(_usd);

--- a/contracts/mocks/MockSwapRouter.sol
+++ b/contracts/mocks/MockSwapRouter.sol
@@ -19,6 +19,7 @@ interface IMintableERC20 {
  */
 contract MockSwapRouter {
     uint256 private _outputAmount;
+    uint256 public swapCallCount;
 
     struct ExactInputSingleParams {
         address tokenIn;
@@ -48,6 +49,9 @@ contract MockSwapRouter {
         payable
         returns (uint256 amountOut)
     {
+        // Track call count for testing
+        swapCallCount++;
+
         // Pull input tokens from caller (simulates pool callback behavior)
         IERC20(params.tokenIn).transferFrom(msg.sender, address(this), params.amountIn);
 

--- a/contracts/mocks/RejectNative.sol
+++ b/contracts/mocks/RejectNative.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title RejectNative
+ * @notice Contract that rejects all native token transfers
+ * @dev Used for testing TransferFailed error handling in JuiceSwapGateway
+ */
+contract RejectNative {
+    error NativeTokenRejected();
+
+    receive() external payable {
+        revert NativeTokenRejected();
+    }
+
+    fallback() external payable {
+        revert NativeTokenRejected();
+    }
+}

--- a/scripts/registerSusdBridgedToken.ts
+++ b/scripts/registerSusdBridgedToken.ts
@@ -1,0 +1,246 @@
+import { ethers, network as hardhatNetwork } from "hardhat";
+import { ADDRESS } from "@juicedollar/jusd";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  getGasConfig,
+  getNetworkConfig,
+  getConfirmations,
+  formatGasOverrides,
+  validateMinimumBalance,
+  validateContractDeployed,
+} from "./utils/deploy-helpers";
+
+/**
+ * Register SUSD (StartUSD) as a bridged token on JuiceSwapGateway
+ *
+ * This script calls gateway.registerBridgedToken(STABLECOIN_BRIDGE_ADDRESS)
+ * to enable SUSD → any token swaps through the Gateway.
+ *
+ * Note: This is permissionless - anyone can call registerBridgedToken IF the bridge
+ * is an approved JUSD minter (checked on-chain via JUSD governance).
+ *
+ * After registration, the Gateway will automatically handle SUSD conversions:
+ * - Direct path (optimized): SUSD ↔ JUSD, SUSD ↔ other bridged tokens
+ * - Pool path: SUSD ↔ cBTC (via SUSD → JUSD → svJUSD → pool → cBTC)
+ *
+ * This replaces the separate StablecoinBridge routing with unified Gateway routing.
+ */
+async function main() {
+  console.log("========================================");
+  console.log("   Register SUSD as Bridged Token      ");
+  console.log("========================================\n");
+
+  // ============================================
+  // 1. SETUP & VALIDATION
+  // ============================================
+
+  const [signer] = await ethers.getSigners();
+  const network = await ethers.provider.getNetwork();
+  const networkConfig = getNetworkConfig(hardhatNetwork.name);
+  const gasConfig = getGasConfig(hardhatNetwork.name);
+  const confirmations = getConfirmations(hardhatNetwork.name);
+
+  console.log(`📍 Network: ${networkConfig.name} (Chain ID: ${network.chainId})`);
+  console.log(`👤 Signer: ${signer.address}`);
+  console.log(`⏳ Confirmations: ${confirmations}`);
+  console.log("");
+
+  // ============================================
+  // 2. GET ADDRESSES FROM PACKAGES
+  // ============================================
+
+  const chainIdNum = Number(network.chainId);
+
+  // Get JuiceDollar addresses
+  const juiceDollarAddresses = ADDRESS[chainIdNum];
+  if (!juiceDollarAddresses) {
+    throw new Error(
+      `❌ Chain ${chainIdNum} not supported by @juicedollar/jusd.\n` +
+      `   Supported chains: ${Object.keys(ADDRESS).join(", ")}`
+    );
+  }
+
+  const SUSD_ADDRESS = juiceDollarAddresses.startUSD;
+  const BRIDGE_ADDRESS = juiceDollarAddresses.bridgeStartUSD;
+
+  if (!SUSD_ADDRESS) {
+    throw new Error(`❌ SUSD (StartUSD) address not defined for chain ${chainIdNum}`);
+  }
+  if (!BRIDGE_ADDRESS) {
+    throw new Error(`❌ StablecoinBridge address not defined for chain ${chainIdNum}`);
+  }
+
+  // Get Gateway address from deployment file
+  const deploymentPath = path.join(__dirname, "../deployments", networkConfig.folder, "gateway.json");
+  if (!fs.existsSync(deploymentPath)) {
+    throw new Error(
+      `❌ Gateway deployment file not found!\n` +
+      `   Expected path: ${deploymentPath}\n` +
+      `   Please deploy the Gateway first using deployJuiceSwapGateway.ts`
+    );
+  }
+
+  const gatewayDeployment = JSON.parse(fs.readFileSync(deploymentPath, "utf-8"));
+  const GATEWAY_ADDRESS = gatewayDeployment.contracts?.JuiceSwapGateway?.address;
+
+  if (!GATEWAY_ADDRESS) {
+    throw new Error(`❌ JuiceSwapGateway address not found in deployment file`);
+  }
+
+  console.log("📦 Addresses from packages:");
+  console.log(`   SUSD (StartUSD):      ${SUSD_ADDRESS}`);
+  console.log(`   StablecoinBridge:     ${BRIDGE_ADDRESS}`);
+  console.log(`   JuiceSwapGateway:     ${GATEWAY_ADDRESS}`);
+  console.log("");
+
+  // ============================================
+  // 3. VALIDATE CONTRACTS EXIST
+  // ============================================
+
+  console.log("🔍 Validating contracts...");
+  await validateContractDeployed(SUSD_ADDRESS, "SUSD");
+  console.log(`   ✅ SUSD: ${SUSD_ADDRESS}`);
+
+  await validateContractDeployed(BRIDGE_ADDRESS, "StablecoinBridge");
+  console.log(`   ✅ StablecoinBridge: ${BRIDGE_ADDRESS}`);
+
+  await validateContractDeployed(GATEWAY_ADDRESS, "JuiceSwapGateway");
+  console.log(`   ✅ JuiceSwapGateway: ${GATEWAY_ADDRESS}`);
+  console.log("");
+
+  // ============================================
+  // 4. CONNECT TO GATEWAY
+  // ============================================
+
+  const gateway = await ethers.getContractAt("IJuiceSwapGateway", GATEWAY_ADDRESS, signer);
+
+  // Check if SUSD is already registered
+  const isAlreadyBridged = await gateway.isBridgedToken(SUSD_ADDRESS);
+  if (isAlreadyBridged) {
+    console.log("✅ SUSD is already registered as a bridged token!");
+    console.log("   No action needed.");
+    return;
+  }
+
+  // ============================================
+  // 5. VALIDATE BRIDGE IS APPROVED JUSD MINTER
+  // ============================================
+
+  const JUSD_ADDRESS = juiceDollarAddresses.JUSD;
+  if (!JUSD_ADDRESS) {
+    throw new Error(`❌ JUSD address not defined for chain ${chainIdNum}`);
+  }
+
+  // Check if bridge is an approved JUSD minter (required for permissionless registration)
+  const jusd = await ethers.getContractAt(
+    ["function isMinter(address) external view returns (bool)"],
+    JUSD_ADDRESS,
+    signer
+  );
+
+  const isMinter = await jusd.isMinter(BRIDGE_ADDRESS);
+  if (!isMinter) {
+    throw new Error(
+      `❌ StablecoinBridge is not an approved JUSD minter!\n` +
+      `   Bridge: ${BRIDGE_ADDRESS}\n` +
+      `   The bridge must be approved via JUSD governance before registration.\n` +
+      `   (suggestMinter() → 14+ day veto period → then registration possible)`
+    );
+  }
+
+  console.log(`✅ Bridge is approved JUSD minter`);
+  console.log("");
+
+  // ============================================
+  // 6. ESTIMATE GAS & CHECK BALANCE
+  // ============================================
+
+  console.log("💰 Checking balance...");
+  const estimatedGas = BigInt(100000); // Conservative estimate for registerBridgedToken
+  const maxFeePerGas = ethers.parseUnits(gasConfig.maxFeePerGas, "gwei");
+  const estimatedCost = estimatedGas * maxFeePerGas;
+  await validateMinimumBalance(signer.address, estimatedCost);
+
+  // ============================================
+  // 7. REGISTER SUSD AS BRIDGED TOKEN
+  // ============================================
+
+  console.log("🚀 Registering SUSD as bridged token...");
+  console.log(`   Calling: gateway.registerBridgedToken(${BRIDGE_ADDRESS})`);
+
+  const tx = await gateway.registerBridgedToken(
+    BRIDGE_ADDRESS,
+    formatGasOverrides(gasConfig, 200000)
+  );
+
+  console.log(`   📝 Tx Hash: ${tx.hash}`);
+  console.log(`   ⏳ Waiting for ${confirmations} confirmation(s)...`);
+
+  const receipt = await tx.wait(confirmations);
+
+  console.log(`   ✅ Transaction confirmed in block ${receipt?.blockNumber}`);
+  console.log("");
+
+  // ============================================
+  // 8. VERIFY REGISTRATION
+  // ============================================
+
+  console.log("🔍 Verifying registration...");
+
+  const isNowBridged = await gateway.isBridgedToken(SUSD_ADDRESS);
+  if (!isNowBridged) {
+    throw new Error("❌ Registration verification failed - SUSD is not marked as bridged!");
+  }
+
+  const bridgedTokens = await gateway.getBridgedTokens();
+  console.log(`   ✅ SUSD is registered as bridged token`);
+  console.log(`   📋 All bridged tokens: ${bridgedTokens.join(", ")}`);
+  console.log("");
+
+  // Check bridge status
+  const bridgeStatus = await gateway.getBridgeStatus(SUSD_ADDRESS);
+  console.log("📊 Bridge Status:");
+  console.log(`   Can Mint (SUSD → JUSD): ${bridgeStatus.canMint}`);
+  console.log(`   Can Burn (JUSD → SUSD): ${bridgeStatus.canBurn}`);
+  console.log(`   Mint Capacity: ${ethers.formatEther(bridgeStatus.mintCapacity)} JUSD`);
+  console.log(`   Burn Capacity: ${ethers.formatEther(bridgeStatus.burnCapacity)} SUSD`);
+  if (bridgeStatus.mintBlockReason) {
+    console.log(`   ⚠️  Mint blocked: ${bridgeStatus.mintBlockReason}`);
+  }
+  if (bridgeStatus.burnBlockReason) {
+    console.log(`   ⚠️  Burn blocked: ${bridgeStatus.burnBlockReason}`);
+  }
+  console.log("");
+
+  // ============================================
+  // 9. SUMMARY
+  // ============================================
+
+  console.log("========================================");
+  console.log("        Registration Complete!         ");
+  console.log("========================================\n");
+
+  console.log("📊 Summary:");
+  console.log(`   SUSD:              ${SUSD_ADDRESS}`);
+  console.log(`   StablecoinBridge:  ${BRIDGE_ADDRESS}`);
+  console.log(`   Gateway:           ${GATEWAY_ADDRESS}`);
+  console.log(`   Transaction:       ${tx.hash}`);
+  console.log("");
+
+  if (networkConfig.explorerUrl) {
+    console.log("🔗 Explorer Links:");
+    console.log(`   Tx: ${networkConfig.explorerUrl}/tx/${tx.hash}`);
+    console.log("");
+  }
+
+  console.log("🎉 SUSD is now routed through Gateway!");
+  console.log("   Users can now swap SUSD → any token via Gateway.");
+  console.log("   Example: SUSD → cBTC (automatically: SUSD → JUSD → svJUSD → cBTC)");
+  console.log("");
+}
+
+main().catch((error) => {
+  console.error("\n❌ Registration failed:", error);
+  process.exitCode = 1;
+});

--- a/test/JuiceSwapGateway.integration.ts
+++ b/test/JuiceSwapGateway.integration.ts
@@ -108,7 +108,7 @@ const isIntegrationTest = network.name === "citreaTestnet";
           return {
             amountA: parsed.args.amountA,
             amountB: parsed.args.amountB,
-            liquidity: parsed.args.liquidity
+            liquidity: parsed.args.liquidity,
           };
         }
       } catch {
@@ -195,7 +195,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       const wcbtcAfter = await wcbtc.balanceOf(signerAddress);
       const jusdSpent = jusdBefore - jusdAfter;
       const wcbtcReceived = wcbtcAfter - wcbtcBefore;
-      console.log(`    Spent: ${ethers.formatUnits(jusdSpent, 6)} JUSD, Received: ${ethers.formatUnits(wcbtcReceived, 18)} WcBTC`);
+      console.log(
+        `    Spent: ${ethers.formatUnits(jusdSpent, 6)} JUSD, Received: ${ethers.formatUnits(wcbtcReceived, 18)} WcBTC`
+      );
 
       expect(receipt.status).to.equal(1);
 
@@ -238,7 +240,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       const jusdAfter = await jusd.balanceOf(signerAddress);
       const wcbtcSpent = wcbtcBefore - wcbtcAfter;
       const jusdReceived = jusdAfter - jusdBefore;
-      console.log(`    Spent: ${ethers.formatUnits(wcbtcSpent, 18)} WcBTC, Received: ${ethers.formatUnits(jusdReceived, 6)} JUSD`);
+      console.log(
+        `    Spent: ${ethers.formatUnits(wcbtcSpent, 18)} WcBTC, Received: ${ethers.formatUnits(jusdReceived, 6)} JUSD`
+      );
 
       expect(receipt.status).to.equal(1);
 
@@ -319,7 +323,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       const juiceAfter = await juice.balanceOf(signerAddress);
       const wcbtcSpent = wcbtcBefore - wcbtcAfter;
       const juiceReceived = juiceAfter - juiceBefore;
-      console.log(`    Spent: ${ethers.formatUnits(wcbtcSpent, 18)} WcBTC, Received: ${ethers.formatUnits(juiceReceived, 18)} JUICE`);
+      console.log(
+        `    Spent: ${ethers.formatUnits(wcbtcSpent, 18)} WcBTC, Received: ${ethers.formatUnits(juiceReceived, 18)} JUICE`
+      );
 
       expect(receipt.status).to.equal(1);
 
@@ -397,11 +403,15 @@ const isIntegrationTest = network.name === "citreaTestnet";
       const jusdBefore = await jusd.balanceOf(signerAddress);
       const wcbtcBefore = await wcbtc.balanceOf(signerAddress);
 
-      console.log(`    Adding liquidity: ${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(wcbtcAmount, 18)} WcBTC...`);
+      console.log(
+        `    Adding liquidity: ${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(wcbtcAmount, 18)} WcBTC...`
+      );
       const tx = await gateway.addLiquidity(
         ADDRESSES.JUSD,
         ADDRESSES.WcBTC,
         FEE,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         jusdAmount,
         wcbtcAmount,
         0,
@@ -463,7 +473,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       const jusdBefore = await jusd.balanceOf(signerAddress);
       const wcbtcBefore = await wcbtc.balanceOf(signerAddress);
 
-      console.log(`    Increasing liquidity: +${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(wcbtcAmount, 18)} WcBTC...`);
+      console.log(
+        `    Increasing liquidity: +${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(wcbtcAmount, 18)} WcBTC...`
+      );
       const tx = await gateway.increaseLiquidity(
         positionTokenId,
         ADDRESSES.JUSD,
@@ -481,7 +493,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       const eventData = findLiquidityIncreasedEvent(receipt);
       expect(eventData).to.not.be.null;
       console.log(`    Liquidity added: ${eventData!.liquidity}`);
-      console.log(`    Event amounts: ${ethers.formatUnits(eventData!.amountA, 6)} JUSD, ${ethers.formatUnits(eventData!.amountB, 18)} WcBTC`);
+      console.log(
+        `    Event amounts: ${ethers.formatUnits(eventData!.amountA, 6)} JUSD, ${ethers.formatUnits(eventData!.amountB, 18)} WcBTC`
+      );
 
       // Verify NFT returned to user
       const owner = await positionManager.ownerOf(positionTokenId);
@@ -505,9 +519,7 @@ const isIntegrationTest = network.name === "citreaTestnet";
       expect(eventData!.amountB).to.equal(wcbtcSpent);
       // JUSD: close match (small variance due to svJUSD exchange rate conversions)
       // Allow 1% tolerance for the JUSD→svJUSD→JUSD round-trip
-      const jusdDiff = eventData!.amountA > jusdSpent
-        ? eventData!.amountA - jusdSpent
-        : jusdSpent - eventData!.amountA;
+      const jusdDiff = eventData!.amountA > jusdSpent ? eventData!.amountA - jusdSpent : jusdSpent - eventData!.amountA;
       const tolerance = jusdSpent / 100n; // 1%
       expect(jusdDiff).to.be.lte(tolerance);
     });
@@ -562,7 +574,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       // Verify tokens received (check each individually since they have different decimals)
       const jusdAfter = await jusd.balanceOf(signerAddress);
       const wcbtcAfter = await wcbtc.balanceOf(signerAddress);
-      console.log(`    Received: ${ethers.formatUnits(jusdAfter - jusdBefore, 6)} JUSD, ${ethers.formatUnits(wcbtcAfter - wcbtcBefore, 18)} WcBTC`);
+      console.log(
+        `    Received: ${ethers.formatUnits(jusdAfter - jusdBefore, 6)} JUSD, ${ethers.formatUnits(wcbtcAfter - wcbtcBefore, 18)} WcBTC`
+      );
       expect(jusdAfter).to.be.gt(jusdBefore);
       expect(wcbtcAfter).to.be.gt(wcbtcBefore);
     });
@@ -609,7 +623,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       // Verify tokens received (check each individually since they have different decimals)
       const jusdAfter = await jusd.balanceOf(signerAddress);
       const wcbtcAfter = await wcbtc.balanceOf(signerAddress);
-      console.log(`    Received: ${ethers.formatUnits(jusdAfter - jusdBefore, 6)} JUSD, ${ethers.formatUnits(wcbtcAfter - wcbtcBefore, 18)} WcBTC`);
+      console.log(
+        `    Received: ${ethers.formatUnits(jusdAfter - jusdBefore, 6)} JUSD, ${ethers.formatUnits(wcbtcAfter - wcbtcBefore, 18)} WcBTC`
+      );
       expect(jusdAfter).to.be.gt(jusdBefore);
       expect(wcbtcAfter).to.be.gt(wcbtcBefore);
     });
@@ -635,11 +651,15 @@ const isIntegrationTest = network.name === "citreaTestnet";
 
       const jusdBefore = await jusd.balanceOf(signerAddress);
 
-      console.log(`    Adding liquidity: ${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(cbtcAmount, 18)} native cBTC...`);
+      console.log(
+        `    Adding liquidity: ${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(cbtcAmount, 18)} native cBTC...`
+      );
       const tx = await gateway.addLiquidity(
         ADDRESSES.JUSD,
         ethers.ZeroAddress, // native cBTC
         FEE,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         jusdAmount,
         cbtcAmount,
         0,
@@ -698,7 +718,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
 
       const jusdBefore = await jusd.balanceOf(signerAddress);
 
-      console.log(`    Increasing liquidity: +${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(cbtcAmount, 18)} native cBTC...`);
+      console.log(
+        `    Increasing liquidity: +${ethers.formatUnits(jusdAmount, 6)} JUSD + ${ethers.formatUnits(cbtcAmount, 18)} native cBTC...`
+      );
       const tx = await gateway.increaseLiquidity(
         positionTokenId,
         ADDRESSES.JUSD,
@@ -717,7 +739,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       const eventData = findLiquidityIncreasedEvent(receipt);
       expect(eventData).to.not.be.null;
       console.log(`    Liquidity added: ${eventData!.liquidity}`);
-      console.log(`    Event amounts: ${ethers.formatUnits(eventData!.amountA, 6)} JUSD, ${ethers.formatUnits(eventData!.amountB, 18)} cBTC`);
+      console.log(
+        `    Event amounts: ${ethers.formatUnits(eventData!.amountA, 6)} JUSD, ${ethers.formatUnits(eventData!.amountB, 18)} cBTC`
+      );
 
       // Verify NFT returned to user
       const owner = await positionManager.ownerOf(positionTokenId);
@@ -735,9 +759,7 @@ const isIntegrationTest = network.name === "citreaTestnet";
 
       // Verify event amounts
       // JUSD: close match (small variance due to svJUSD exchange rate conversions)
-      const jusdDiff = eventData!.amountA > jusdSpent
-        ? eventData!.amountA - jusdSpent
-        : jusdSpent - eventData!.amountA;
+      const jusdDiff = eventData!.amountA > jusdSpent ? eventData!.amountA - jusdSpent : jusdSpent - eventData!.amountA;
       const tolerance = jusdSpent / 100n; // 1%
       expect(jusdDiff).to.be.lte(tolerance);
       // Native cBTC: verify it's non-zero and at most what was sent (can't verify exact due to gas)
@@ -783,7 +805,9 @@ const isIntegrationTest = network.name === "citreaTestnet";
       expect(removedEvent!.amountA).to.be.gt(0); // JUSD amount
       expect(removedEvent!.amountB).to.be.gt(0); // cBTC amount (proves gateway processed the WcBTC)
 
-      console.log(`    Event amounts: ${ethers.formatUnits(removedEvent!.amountA, 6)} JUSD, ${ethers.formatUnits(removedEvent!.amountB, 18)} cBTC`);
+      console.log(
+        `    Event amounts: ${ethers.formatUnits(removedEvent!.amountA, 6)} JUSD, ${ethers.formatUnits(removedEvent!.amountB, 18)} cBTC`
+      );
 
       // Verify all liquidity was removed from position
       const liquidityAfter = await getPositionLiquidity(positionTokenId);

--- a/test/JuiceSwapGateway.swapMatrix.test.ts
+++ b/test/JuiceSwapGateway.swapMatrix.test.ts
@@ -1,0 +1,1138 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import {
+  JuiceSwapGateway,
+  MockERC20,
+  MockEquity,
+  MockERC4626,
+  MockWETH,
+  MockSwapRouter,
+  MockPositionManager,
+  MockStablecoinBridge,
+} from "../typechain-types";
+import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+/**
+ * Comprehensive Swap Matrix Tests
+ *
+ * Tests all 72 swap directions (36 pairs) for the 9 supported tokens:
+ * - cBTC (native)
+ * - WcBTC
+ * - JUSD
+ * - svJUSD
+ * - JUICE
+ * - USDT.e (bridged)
+ * - USDC.e (bridged)
+ * - SUSD (bridged)
+ * - ctUSD (bridged)
+ */
+describe("JuiceSwapGateway - Complete Swap Matrix", function () {
+  // Test constants
+  const INITIAL_BALANCE = ethers.parseEther("10000");
+  const DEADLINE_OFFSET = 3600;
+  const BRIDGE_LIMIT = ethers.parseEther("1000000000"); // 1B JUSD (high limit for testing)
+  const BRIDGE_WEEKS = 208; // 4 years
+
+  // Token identifiers for the matrix
+  type TokenId =
+    | "cBTC"
+    | "WcBTC"
+    | "JUSD"
+    | "svJUSD"
+    | "JUICE"
+    | "USDT"
+    | "USDC"
+    | "SUSD"
+    | "ctUSD";
+
+  interface TokenInfo {
+    id: TokenId;
+    decimals: number;
+    isBridged: boolean;
+    isNative: boolean;
+  }
+
+  const TOKEN_INFO: Record<TokenId, TokenInfo> = {
+    cBTC: { id: "cBTC", decimals: 18, isBridged: false, isNative: true },
+    WcBTC: { id: "WcBTC", decimals: 18, isBridged: false, isNative: false },
+    JUSD: { id: "JUSD", decimals: 18, isBridged: false, isNative: false },
+    svJUSD: { id: "svJUSD", decimals: 18, isBridged: false, isNative: false },
+    JUICE: { id: "JUICE", decimals: 18, isBridged: false, isNative: false },
+    USDT: { id: "USDT", decimals: 6, isBridged: true, isNative: false },
+    USDC: { id: "USDC", decimals: 6, isBridged: true, isNative: false },
+    SUSD: { id: "SUSD", decimals: 18, isBridged: true, isNative: false },
+    ctUSD: { id: "ctUSD", decimals: 6, isBridged: true, isNative: false },
+  };
+
+  const ALL_TOKENS: TokenId[] = [
+    "cBTC",
+    "WcBTC",
+    "JUSD",
+    "svJUSD",
+    "JUICE",
+    "USDT",
+    "USDC",
+    "SUSD",
+    "ctUSD",
+  ];
+
+  interface FixtureResult {
+    owner: HardhatEthersSigner;
+    user1: HardhatEthersSigner;
+    gateway: JuiceSwapGateway;
+    jusd: MockERC20;
+    juice: MockEquity;
+    svJusd: MockERC4626;
+    wcbtc: MockWETH;
+    swapRouter: MockSwapRouter;
+    positionManager: MockPositionManager;
+    usdt: MockERC20;
+    usdc: MockERC20;
+    susd: MockERC20;
+    ctUsd: MockERC20;
+    usdtBridge: MockStablecoinBridge;
+    usdcBridge: MockStablecoinBridge;
+    susdBridge: MockStablecoinBridge;
+    ctUsdBridge: MockStablecoinBridge;
+    getTokenAddress: (id: TokenId) => Promise<string>;
+    getTokenContract: (id: TokenId) => MockERC20 | MockEquity | MockERC4626 | MockWETH;
+    getBridge: (id: TokenId) => MockStablecoinBridge | null;
+  }
+
+  /**
+   * Deploy complete fixture with all 9 tokens
+   */
+  async function deployCompleteFixture(): Promise<FixtureResult> {
+    const [owner, user1] = await ethers.getSigners();
+
+    // Deploy core mocks
+    const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+    const jusd = (await MockERC20Factory.deploy(
+      "JuiceDollar",
+      "JUSD",
+      18
+    )) as unknown as MockERC20;
+
+    const MockEquityFactory = await ethers.getContractFactory("MockEquity");
+    const juice = (await MockEquityFactory.deploy(
+      "Juice Protocol",
+      "JUICE",
+      await jusd.getAddress()
+    )) as unknown as MockEquity;
+
+    const MockERC4626Factory = await ethers.getContractFactory("MockERC4626");
+    const svJusd = (await MockERC4626Factory.deploy(
+      await jusd.getAddress(),
+      "Savings Vault JUSD",
+      "svJUSD"
+    )) as unknown as MockERC4626;
+
+    const MockWETHFactory = await ethers.getContractFactory("MockWETH");
+    const wcbtc = (await MockWETHFactory.deploy(
+      "Wrapped cBTC",
+      "WcBTC"
+    )) as unknown as MockWETH;
+
+    const MockSwapRouterFactory =
+      await ethers.getContractFactory("MockSwapRouter");
+    const swapRouter =
+      (await MockSwapRouterFactory.deploy()) as unknown as MockSwapRouter;
+
+    const MockPositionManagerFactory =
+      await ethers.getContractFactory("MockPositionManager");
+    const positionManager =
+      (await MockPositionManagerFactory.deploy()) as unknown as MockPositionManager;
+
+    // Deploy gateway
+    const JuiceSwapGatewayFactory =
+      await ethers.getContractFactory("JuiceSwapGateway");
+    const gateway = (await JuiceSwapGatewayFactory.deploy(
+      await jusd.getAddress(),
+      await svJusd.getAddress(),
+      await juice.getAddress(),
+      await wcbtc.getAddress(),
+      await swapRouter.getAddress(),
+      await positionManager.getAddress()
+    )) as unknown as JuiceSwapGateway;
+
+    // Deploy bridged stablecoins
+    const usdt = (await MockERC20Factory.deploy(
+      "Tether USD",
+      "USDT.e",
+      6
+    )) as unknown as MockERC20;
+    const usdc = (await MockERC20Factory.deploy(
+      "USD Coin",
+      "USDC.e",
+      6
+    )) as unknown as MockERC20;
+    const susd = (await MockERC20Factory.deploy(
+      "StartUSD",
+      "SUSD",
+      18
+    )) as unknown as MockERC20;
+    const ctUsd = (await MockERC20Factory.deploy(
+      "M0 USD",
+      "ctUSD",
+      6
+    )) as unknown as MockERC20;
+
+    // Deploy bridges
+    const MockBridgeFactory =
+      await ethers.getContractFactory("MockStablecoinBridge");
+    const usdtBridge = (await MockBridgeFactory.deploy(
+      await usdt.getAddress(),
+      await jusd.getAddress(),
+      BRIDGE_LIMIT,
+      BRIDGE_WEEKS
+    )) as unknown as MockStablecoinBridge;
+    const usdcBridge = (await MockBridgeFactory.deploy(
+      await usdc.getAddress(),
+      await jusd.getAddress(),
+      BRIDGE_LIMIT,
+      BRIDGE_WEEKS
+    )) as unknown as MockStablecoinBridge;
+    const susdBridge = (await MockBridgeFactory.deploy(
+      await susd.getAddress(),
+      await jusd.getAddress(),
+      BRIDGE_LIMIT,
+      BRIDGE_WEEKS
+    )) as unknown as MockStablecoinBridge;
+    const ctUsdBridge = (await MockBridgeFactory.deploy(
+      await ctUsd.getAddress(),
+      await jusd.getAddress(),
+      BRIDGE_LIMIT,
+      BRIDGE_WEEKS
+    )) as unknown as MockStablecoinBridge;
+
+    // Set bridges as approved minters
+    await jusd.setMinter(await usdtBridge.getAddress(), true);
+    await jusd.setMinter(await usdcBridge.getAddress(), true);
+    await jusd.setMinter(await susdBridge.getAddress(), true);
+    await jusd.setMinter(await ctUsdBridge.getAddress(), true);
+
+    // Register bridged tokens
+    await gateway.registerBridgedToken(await usdtBridge.getAddress());
+    await gateway.registerBridgedToken(await usdcBridge.getAddress());
+    await gateway.registerBridgedToken(await susdBridge.getAddress());
+    await gateway.registerBridgedToken(await ctUsdBridge.getAddress());
+
+    // Fund bridges with tokens for burn operations
+    const bridgeFunding6Dec = 100_000_000n * 10n ** 6n; // 100M (6 decimals)
+    const bridgeFunding18Dec = ethers.parseEther("100000000"); // 100M (18 decimals)
+    await usdt.mint(await usdtBridge.getAddress(), bridgeFunding6Dec);
+    await usdc.mint(await usdcBridge.getAddress(), bridgeFunding6Dec);
+    await susd.mint(await susdBridge.getAddress(), bridgeFunding18Dec);
+    await ctUsd.mint(await ctUsdBridge.getAddress(), bridgeFunding6Dec);
+
+    // Set initial minted amounts for all bridges (needed for burn operations)
+    // Must be > 0 for burn operations but not exceed limit
+    await usdtBridge.setMinted(ethers.parseEther("10000000"));
+    await usdcBridge.setMinted(ethers.parseEther("10000000"));
+    await susdBridge.setMinted(ethers.parseEther("10000000"));
+    await ctUsdBridge.setMinted(ethers.parseEther("10000000"));
+
+    // Setup user balances
+    await jusd.mint(user1.address, INITIAL_BALANCE);
+    await juice.mint(user1.address, INITIAL_BALANCE);
+    await wcbtc.connect(user1).deposit({ value: ethers.parseEther("1000") });
+
+    // Fund user with bridged tokens
+    await usdt.mint(user1.address, 1_000_000n * 10n ** 6n);
+    await usdc.mint(user1.address, 1_000_000n * 10n ** 6n);
+    await susd.mint(user1.address, ethers.parseEther("1000000"));
+    await ctUsd.mint(user1.address, 1_000_000n * 10n ** 6n);
+
+    // Fund svJUSD vault with JUSD for redemptions
+    await jusd.mint(await svJusd.getAddress(), ethers.parseEther("10000000"));
+
+    // Fund JUICE contract with JUSD for redemptions
+    await jusd.mint(await juice.getAddress(), ethers.parseEther("10000000"));
+
+    // Mint svJUSD to user for svJUSD input tests
+    await jusd.mint(user1.address, ethers.parseEther("100000"));
+    await jusd
+      .connect(user1)
+      .approve(await svJusd.getAddress(), ethers.parseEther("100000"));
+    await svJusd
+      .connect(user1)
+      ["deposit(uint256,address)"](
+        ethers.parseEther("100000"),
+        user1.address
+      );
+
+    // Helper functions
+    const getTokenAddress = async (id: TokenId): Promise<string> => {
+      switch (id) {
+        case "cBTC":
+          return ethers.ZeroAddress;
+        case "WcBTC":
+          return await wcbtc.getAddress();
+        case "JUSD":
+          return await jusd.getAddress();
+        case "svJUSD":
+          return await svJusd.getAddress();
+        case "JUICE":
+          return await juice.getAddress();
+        case "USDT":
+          return await usdt.getAddress();
+        case "USDC":
+          return await usdc.getAddress();
+        case "SUSD":
+          return await susd.getAddress();
+        case "ctUSD":
+          return await ctUsd.getAddress();
+      }
+    };
+
+    const getTokenContract = (
+      id: TokenId
+    ): MockERC20 | MockEquity | MockERC4626 | MockWETH => {
+      switch (id) {
+        case "cBTC":
+        case "WcBTC":
+          return wcbtc;
+        case "JUSD":
+          return jusd;
+        case "svJUSD":
+          return svJusd as unknown as MockERC4626;
+        case "JUICE":
+          return juice;
+        case "USDT":
+          return usdt;
+        case "USDC":
+          return usdc;
+        case "SUSD":
+          return susd;
+        case "ctUSD":
+          return ctUsd;
+      }
+    };
+
+    const getBridge = (id: TokenId): MockStablecoinBridge | null => {
+      switch (id) {
+        case "USDT":
+          return usdtBridge;
+        case "USDC":
+          return usdcBridge;
+        case "SUSD":
+          return susdBridge;
+        case "ctUSD":
+          return ctUsdBridge;
+        default:
+          return null;
+      }
+    };
+
+    return {
+      owner,
+      user1,
+      gateway,
+      jusd,
+      juice,
+      svJusd,
+      wcbtc,
+      swapRouter,
+      positionManager,
+      usdt,
+      usdc,
+      susd,
+      ctUsd,
+      usdtBridge,
+      usdcBridge,
+      susdBridge,
+      ctUsdBridge,
+      getTokenAddress,
+      getTokenContract,
+      getBridge,
+    };
+  }
+
+  /**
+   * Get the pool token that a user token converts to
+   */
+  function getPoolToken(tokenId: TokenId): "WcBTC" | "svJUSD" {
+    if (tokenId === "cBTC" || tokenId === "WcBTC") {
+      return "WcBTC";
+    }
+    return "svJUSD";
+  }
+
+  /**
+   * Determine swap type based on input/output tokens
+   */
+  function getSwapType(
+    tokenIn: TokenId,
+    tokenOut: TokenId
+  ): "pool" | "direct" | "wrap" {
+    const poolIn = getPoolToken(tokenIn);
+    const poolOut = getPoolToken(tokenOut);
+
+    // Wrap/unwrap between cBTC and WcBTC
+    if (
+      (tokenIn === "cBTC" && tokenOut === "WcBTC") ||
+      (tokenIn === "WcBTC" && tokenOut === "cBTC")
+    ) {
+      return "wrap";
+    }
+
+    // Pool swap if crossing between WcBTC and svJUSD groups
+    if (poolIn !== poolOut) {
+      return "pool";
+    }
+
+    // Direct conversion within the same group
+    return "direct";
+  }
+
+  /**
+   * Get appropriate swap amount based on token decimals
+   */
+  function getSwapAmount(tokenId: TokenId): bigint {
+    const info = TOKEN_INFO[tokenId];
+    if (info.decimals === 6) {
+      return 1000n * 10n ** 6n; // 1000 units for 6 decimal tokens
+    }
+    return ethers.parseEther("100"); // 100 units for 18 decimal tokens
+  }
+
+  /**
+   * Setup mock router for pool swaps
+   */
+  async function setupPoolSwap(
+    fixture: FixtureResult,
+    tokenIn: TokenId,
+    tokenOut: TokenId
+  ): Promise<bigint> {
+    const { swapRouter, svJusd, wcbtc } = fixture;
+
+    // Calculate expected output based on direction
+    const poolIn = getPoolToken(tokenIn);
+    const poolOut = getPoolToken(tokenOut);
+
+    let mockOutput: bigint;
+
+    if (poolIn === "WcBTC" && poolOut === "svJUSD") {
+      // WcBTC → svJUSD (e.g., 0.01 WcBTC → 1000 svJUSD)
+      mockOutput = ethers.parseEther("1000");
+      await svJusd["mint(address,uint256)"](
+        await swapRouter.getAddress(),
+        mockOutput
+      );
+    } else {
+      // svJUSD → WcBTC (e.g., 1000 svJUSD → 0.01 WcBTC)
+      mockOutput = ethers.parseEther("0.01");
+      await wcbtc.connect(fixture.owner).deposit({ value: mockOutput });
+      await wcbtc
+        .connect(fixture.owner)
+        .transfer(await swapRouter.getAddress(), mockOutput);
+    }
+
+    await swapRouter.setSwapOutput(mockOutput);
+    return mockOutput;
+  }
+
+  describe("Swap Matrix - All 72 Directions", function () {
+    // Generate test cases for all token pairs
+    for (const tokenIn of ALL_TOKENS) {
+      for (const tokenOut of ALL_TOKENS) {
+        if (tokenIn === tokenOut) continue;
+
+        const swapType = getSwapType(tokenIn, tokenOut);
+        const testName = `${tokenIn} → ${tokenOut} (${swapType})`;
+
+        it(`Should swap ${testName}`, async function () {
+          const fixture = await loadFixture(deployCompleteFixture);
+          const { gateway, user1, getTokenAddress, getTokenContract, getBridge } =
+            fixture;
+
+          const deadline = (await time.latest()) + DEADLINE_OFFSET;
+          const tokenInAddr = await getTokenAddress(tokenIn);
+          const tokenOutAddr = await getTokenAddress(tokenOut);
+          const swapAmount = getSwapAmount(tokenIn);
+          const tokenInfo = TOKEN_INFO[tokenIn];
+
+          // Setup for pool swaps
+          if (swapType === "pool") {
+            await setupPoolSwap(fixture, tokenIn, tokenOut);
+          }
+
+          // Get balance before
+          let balanceBefore: bigint;
+          if (tokenOut === "cBTC") {
+            balanceBefore = await ethers.provider.getBalance(user1.address);
+          } else {
+            const outContract = getTokenContract(tokenOut);
+            balanceBefore = await outContract.balanceOf(user1.address);
+          }
+
+          // Approve gateway if not native token
+          if (!tokenInfo.isNative) {
+            const inContract = getTokenContract(tokenIn);
+            await inContract
+              .connect(user1)
+              .approve(await gateway.getAddress(), swapAmount);
+          }
+
+          // Execute swap
+          const txOptions = tokenInfo.isNative ? { value: swapAmount } : {};
+          await gateway.connect(user1).swapExactTokensForTokens(
+            tokenInAddr,
+            tokenOutAddr,
+            0, // use default fee
+            swapAmount,
+            0, // min output (we just want to verify it works)
+            user1.address,
+            deadline,
+            txOptions
+          );
+
+          // Verify balance increased
+          let balanceAfter: bigint;
+          if (tokenOut === "cBTC") {
+            balanceAfter = await ethers.provider.getBalance(user1.address);
+            // Account for gas costs - just verify we got some output
+            // For wrap/unwrap the balance should be close
+          } else {
+            const outContract = getTokenContract(tokenOut);
+            balanceAfter = await outContract.balanceOf(user1.address);
+          }
+
+          // Verify output was received (balance increased)
+          expect(balanceAfter).to.be.gte(
+            balanceBefore,
+            `${testName}: Output balance should increase`
+          );
+        });
+      }
+    }
+  });
+
+  describe("Swap Path Verification", function () {
+    describe("Pool Swaps (WcBTC ↔ svJUSD group)", function () {
+      const poolSwapPairs: [TokenId, TokenId][] = [
+        ["cBTC", "JUSD"],
+        ["cBTC", "svJUSD"],
+        ["cBTC", "JUICE"],
+        ["cBTC", "USDT"],
+        ["cBTC", "USDC"],
+        ["cBTC", "SUSD"],
+        ["cBTC", "ctUSD"],
+        ["WcBTC", "JUSD"],
+        ["WcBTC", "svJUSD"],
+        ["WcBTC", "JUICE"],
+        ["WcBTC", "USDT"],
+        ["WcBTC", "USDC"],
+        ["WcBTC", "SUSD"],
+        ["WcBTC", "ctUSD"],
+        ["JUSD", "cBTC"],
+        ["JUSD", "WcBTC"],
+        ["svJUSD", "cBTC"],
+        ["svJUSD", "WcBTC"],
+        ["JUICE", "cBTC"],
+        ["JUICE", "WcBTC"],
+        ["USDT", "cBTC"],
+        ["USDT", "WcBTC"],
+        ["USDC", "cBTC"],
+        ["USDC", "WcBTC"],
+        ["SUSD", "cBTC"],
+        ["SUSD", "WcBTC"],
+        ["ctUSD", "cBTC"],
+        ["ctUSD", "WcBTC"],
+      ];
+
+      for (const [tokenIn, tokenOut] of poolSwapPairs) {
+        it(`${tokenIn} → ${tokenOut} should use pool swap`, async function () {
+          const fixture = await loadFixture(deployCompleteFixture);
+          const { gateway, user1, swapRouter, getTokenAddress, getTokenContract } =
+            fixture;
+
+          const deadline = (await time.latest()) + DEADLINE_OFFSET;
+          const tokenInAddr = await getTokenAddress(tokenIn);
+          const tokenOutAddr = await getTokenAddress(tokenOut);
+          const swapAmount = getSwapAmount(tokenIn);
+          const tokenInfo = TOKEN_INFO[tokenIn];
+
+          // Setup mock router
+          await setupPoolSwap(fixture, tokenIn, tokenOut);
+
+          // Track router calls
+          const routerCallsBefore = await swapRouter.swapCallCount();
+
+          // Approve if needed
+          if (!tokenInfo.isNative) {
+            const inContract = getTokenContract(tokenIn);
+            await inContract
+              .connect(user1)
+              .approve(await gateway.getAddress(), swapAmount);
+          }
+
+          // Execute swap
+          const txOptions = tokenInfo.isNative ? { value: swapAmount } : {};
+          await gateway.connect(user1).swapExactTokensForTokens(
+            tokenInAddr,
+            tokenOutAddr,
+            0,
+            swapAmount,
+            0,
+            user1.address,
+            deadline,
+            txOptions
+          );
+
+          // Verify router was called (pool swap)
+          const routerCallsAfter = await swapRouter.swapCallCount();
+          expect(routerCallsAfter).to.be.gt(
+            routerCallsBefore,
+            "Pool swap should call router"
+          );
+        });
+      }
+    });
+
+    describe("Direct Conversions (skip pool)", function () {
+      const directPairs: [TokenId, TokenId][] = [
+        // USD ↔ USD (optimized path)
+        ["JUSD", "USDT"],
+        ["JUSD", "USDC"],
+        ["JUSD", "SUSD"],
+        ["JUSD", "ctUSD"],
+        ["USDT", "JUSD"],
+        ["USDC", "JUSD"],
+        ["SUSD", "JUSD"],
+        ["ctUSD", "JUSD"],
+        // Bridged ↔ Bridged
+        ["USDT", "USDC"],
+        ["USDT", "SUSD"],
+        ["USDT", "ctUSD"],
+        ["USDC", "USDT"],
+        ["USDC", "SUSD"],
+        ["USDC", "ctUSD"],
+        ["SUSD", "USDT"],
+        ["SUSD", "USDC"],
+        ["SUSD", "ctUSD"],
+        ["ctUSD", "USDT"],
+        ["ctUSD", "USDC"],
+        ["ctUSD", "SUSD"],
+        // USD → JUICE (optimized)
+        ["JUSD", "JUICE"],
+        ["USDT", "JUICE"],
+        ["USDC", "JUICE"],
+        ["SUSD", "JUICE"],
+        ["ctUSD", "JUICE"],
+      ];
+
+      for (const [tokenIn, tokenOut] of directPairs) {
+        it(`${tokenIn} → ${tokenOut} should skip pool (direct conversion)`, async function () {
+          const fixture = await loadFixture(deployCompleteFixture);
+          const { gateway, user1, swapRouter, getTokenAddress, getTokenContract } =
+            fixture;
+
+          const deadline = (await time.latest()) + DEADLINE_OFFSET;
+          const tokenInAddr = await getTokenAddress(tokenIn);
+          const tokenOutAddr = await getTokenAddress(tokenOut);
+          const swapAmount = getSwapAmount(tokenIn);
+
+          // Track router calls
+          const routerCallsBefore = await swapRouter.swapCallCount();
+
+          // Approve
+          const inContract = getTokenContract(tokenIn);
+          await inContract
+            .connect(user1)
+            .approve(await gateway.getAddress(), swapAmount);
+
+          // Execute swap
+          await gateway.connect(user1).swapExactTokensForTokens(
+            tokenInAddr,
+            tokenOutAddr,
+            0,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          );
+
+          // Verify router was NOT called (direct conversion)
+          const routerCallsAfter = await swapRouter.swapCallCount();
+          expect(routerCallsAfter).to.equal(
+            routerCallsBefore,
+            "Direct conversion should NOT call router"
+          );
+        });
+      }
+    });
+
+    describe("Wrap/Unwrap (cBTC ↔ WcBTC)", function () {
+      it("cBTC → WcBTC should wrap without pool", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, wcbtc, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1");
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const wcbtcBefore = await wcbtc.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          ethers.ZeroAddress, // cBTC
+          await wcbtc.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline,
+          { value: swapAmount }
+        );
+
+        const wcbtcAfter = await wcbtc.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(wcbtcAfter - wcbtcBefore).to.equal(swapAmount);
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "Wrap should not call router"
+        );
+      });
+
+      it("WcBTC → cBTC should unwrap without pool", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, wcbtc, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1");
+
+        await wcbtc
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const cbtcBefore = await ethers.provider.getBalance(user1.address);
+
+        const tx = await gateway.connect(user1).swapExactTokensForTokens(
+          await wcbtc.getAddress(),
+          ethers.ZeroAddress, // cBTC
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const receipt = await tx.wait();
+        const gasUsed = receipt!.gasUsed * receipt!.gasPrice;
+        const cbtcAfter = await ethers.provider.getBalance(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        // Account for gas in balance check
+        expect(cbtcAfter + gasUsed - cbtcBefore).to.be.closeTo(
+          swapAmount,
+          ethers.parseEther("0.001")
+        );
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "Unwrap should not call router"
+        );
+      });
+    });
+
+    describe("svJUSD Direct Input/Output", function () {
+      it("svJUSD → JUSD should redeem directly", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, svJusd, jusd, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("100");
+
+        await svJusd
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const jusdBefore = await jusd.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await svJusd.getAddress(),
+          await jusd.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const jusdAfter = await jusd.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(jusdAfter).to.be.gt(jusdBefore);
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "svJUSD → JUSD should not call router"
+        );
+      });
+
+      it("JUSD → svJUSD should deposit directly", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, svJusd, jusd, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("100");
+
+        await jusd
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const svJusdBefore = await svJusd.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await svJusd.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const svJusdAfter = await svJusd.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(svJusdAfter).to.be.gt(svJusdBefore);
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "JUSD → svJUSD should not call router"
+        );
+      });
+
+      it("svJUSD → JUICE should convert via JUSD", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, svJusd, juice, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1000");
+
+        await svJusd
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const juiceBefore = await juice.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await svJusd.getAddress(),
+          await juice.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const juiceAfter = await juice.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(juiceAfter).to.be.gt(juiceBefore);
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "svJUSD → JUICE should not call router"
+        );
+      });
+
+      it("svJUSD → WcBTC should use pool swap", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, svJusd, wcbtc, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1000");
+
+        // Setup mock output
+        const mockOutput = ethers.parseEther("0.01");
+        await wcbtc.connect(fixture.owner).deposit({ value: mockOutput });
+        await wcbtc
+          .connect(fixture.owner)
+          .transfer(await swapRouter.getAddress(), mockOutput);
+        await swapRouter.setSwapOutput(mockOutput);
+
+        await svJusd
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const wcbtcBefore = await wcbtc.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await svJusd.getAddress(),
+          await wcbtc.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const wcbtcAfter = await wcbtc.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(wcbtcAfter).to.be.gt(wcbtcBefore);
+        expect(routerCallsAfter).to.be.gt(
+          routerCallsBefore,
+          "svJUSD → WcBTC should call router (pool swap)"
+        );
+      });
+
+      it("svJUSD → bridged token should convert via JUSD", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, svJusd, usdc, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1000");
+
+        await svJusd
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const usdcBefore = await usdc.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await svJusd.getAddress(),
+          await usdc.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const usdcAfter = await usdc.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(usdcAfter).to.be.gt(usdcBefore);
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "svJUSD → bridged should not call router"
+        );
+      });
+    });
+
+    describe("JUICE Input/Output", function () {
+      it("JUICE → JUSD should redeem via redeemFrom", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, juice, jusd, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1");
+
+        await juice
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const jusdBefore = await jusd.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await juice.getAddress(),
+          await jusd.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const jusdAfter = await jusd.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(jusdAfter).to.be.gt(jusdBefore);
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "JUICE → JUSD should not call router"
+        );
+      });
+
+      it("JUICE → bridged should go through JUSD", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, juice, usdt, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1");
+
+        await juice
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const usdtBefore = await usdt.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await juice.getAddress(),
+          await usdt.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const usdtAfter = await usdt.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(usdtAfter).to.be.gt(usdtBefore);
+        // JUICE → bridged goes through svJUSD, so no pool swap
+        expect(routerCallsAfter).to.equal(
+          routerCallsBefore,
+          "JUICE → bridged should not call router"
+        );
+      });
+
+      it("JUICE → WcBTC should use pool swap", async function () {
+        const fixture = await loadFixture(deployCompleteFixture);
+        const { gateway, user1, juice, wcbtc, swapRouter } = fixture;
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = ethers.parseEther("1");
+
+        // Setup mock output
+        const mockOutput = ethers.parseEther("0.001");
+        await wcbtc.connect(fixture.owner).deposit({ value: mockOutput });
+        await wcbtc
+          .connect(fixture.owner)
+          .transfer(await swapRouter.getAddress(), mockOutput);
+        await swapRouter.setSwapOutput(mockOutput);
+
+        await juice
+          .connect(user1)
+          .approve(await gateway.getAddress(), swapAmount);
+
+        const routerCallsBefore = await swapRouter.swapCallCount();
+        const wcbtcBefore = await wcbtc.balanceOf(user1.address);
+
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await juice.getAddress(),
+          await wcbtc.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const wcbtcAfter = await wcbtc.balanceOf(user1.address);
+        const routerCallsAfter = await swapRouter.swapCallCount();
+
+        expect(wcbtcAfter).to.be.gt(wcbtcBefore);
+        expect(routerCallsAfter).to.be.gt(
+          routerCallsBefore,
+          "JUICE → WcBTC should call router (pool swap)"
+        );
+      });
+    });
+  });
+
+  describe("Edge Cases", function () {
+    it("Should handle SUSD (18 decimals bridged token) correctly", async function () {
+      const fixture = await loadFixture(deployCompleteFixture);
+      const { gateway, user1, susd, jusd } = fixture;
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1000");
+
+      await susd.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      const jusdBefore = await jusd.balanceOf(user1.address);
+
+      await gateway.connect(user1).swapExactTokensForTokens(
+        await susd.getAddress(),
+        await jusd.getAddress(),
+        0,
+        swapAmount,
+        0,
+        user1.address,
+        deadline
+      );
+
+      const jusdAfter = await jusd.balanceOf(user1.address);
+
+      // SUSD is 18 decimals, so 1:1 with JUSD
+      expect(jusdAfter - jusdBefore).to.equal(swapAmount);
+    });
+
+    it("Should handle 6 decimal to 18 decimal conversion correctly", async function () {
+      const fixture = await loadFixture(deployCompleteFixture);
+      const { gateway, user1, usdc, jusd } = fixture;
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
+
+      await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      const jusdBefore = await jusd.balanceOf(user1.address);
+
+      await gateway.connect(user1).swapExactTokensForTokens(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        0,
+        swapAmount,
+        0,
+        user1.address,
+        deadline
+      );
+
+      const jusdAfter = await jusd.balanceOf(user1.address);
+
+      // 1000 USDC (6 dec) = 1000 JUSD (18 dec)
+      expect(jusdAfter - jusdBefore).to.equal(ethers.parseEther("1000"));
+    });
+
+    it("Should handle 18 decimal to 6 decimal conversion correctly", async function () {
+      const fixture = await loadFixture(deployCompleteFixture);
+      const { gateway, user1, jusd, usdc, usdcBridge } = fixture;
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1000");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      const usdcBefore = await usdc.balanceOf(user1.address);
+
+      await gateway.connect(user1).swapExactTokensForTokens(
+        await jusd.getAddress(),
+        await usdc.getAddress(),
+        0,
+        swapAmount,
+        0,
+        user1.address,
+        deadline
+      );
+
+      const usdcAfter = await usdc.balanceOf(user1.address);
+
+      // 1000 JUSD (18 dec) = 1000 USDC (6 dec)
+      expect(usdcAfter - usdcBefore).to.equal(1000n * 10n ** 6n);
+    });
+
+    it("Should emit SwapExecuted for all swap types", async function () {
+      const fixture = await loadFixture(deployCompleteFixture);
+      const { gateway, user1, jusd, usdc } = fixture;
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      await expect(
+        gateway.connect(user1).swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await usdc.getAddress(),
+          0,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.emit(gateway, "SwapExecuted");
+    });
+  });
+});

--- a/test/JuiceSwapGateway.test.ts
+++ b/test/JuiceSwapGateway.test.ts
@@ -33,7 +33,11 @@ describe("JuiceSwapGateway", function () {
 
     // Deploy Mock JUICE (ERC20 with Equity functions)
     const MockEquityFactory = await ethers.getContractFactory("MockEquity");
-    const juice = (await MockEquityFactory.deploy("Juice Protocol", "JUICE", await jusd.getAddress())) as unknown as MockEquity;
+    const juice = (await MockEquityFactory.deploy(
+      "Juice Protocol",
+      "JUICE",
+      await jusd.getAddress()
+    )) as unknown as MockEquity;
     await juice.waitForDeployment();
 
     // Deploy Mock svJUSD (ERC4626)
@@ -143,19 +147,9 @@ describe("JuiceSwapGateway", function () {
       expect(await gateway.POSITION_MANAGER()).to.equal(await positionManager.getAddress());
     });
 
-    it("Should set correct default fee tier", async function () {
+    it("Should have correct constant fee tier", async function () {
       const { gateway } = await loadFixture(deployGatewayFixture);
-      expect(await gateway.defaultFee()).to.equal(3000); // 0.3%
-    });
-
-    it("Should set deployer as owner", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-      expect(await gateway.owner()).to.equal(owner.address);
-    });
-
-    it("Should not be paused initially", async function () {
-      const { gateway } = await loadFixture(deployGatewayFixture);
-      expect(await gateway.paused()).to.be.false;
+      expect(await gateway.DEFAULT_FEE()).to.equal(3000); // 0.3% - immutable
     });
   });
 
@@ -203,8 +197,7 @@ describe("JuiceSwapGateway", function () {
 
   describe("Swap: JUSD → Other Token", function () {
     it("Should swap JUSD for another token successfully", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("100");
@@ -215,15 +208,17 @@ describe("JuiceSwapGateway", function () {
       // Approve gateway to spend JUSD
       await jusd.connect(user1).approve(await gateway.getAddress(), swapAmount);
 
-      const tx = await gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        swapAmount,
-        MIN_OUTPUT,
-        user1.address,
-        deadline
-      );
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          swapAmount,
+          MIN_OUTPUT,
+          user1.address,
+          deadline
+        );
 
       await expect(tx)
         .to.emit(gateway, "SwapExecuted")
@@ -232,13 +227,12 @@ describe("JuiceSwapGateway", function () {
           await jusd.getAddress(),
           await wcbtc.getAddress(),
           anyValue, // amountIn (svJUSD shares, varies)
-          anyValue  // amountOut (from mock)
+          anyValue // amountOut (from mock)
         );
     });
 
     it("Should revert if deadline expired", async function () {
-      const { gateway, user1, jusd, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const pastDeadline = (await time.latest()) - 1;
       const swapAmount = ethers.parseEther("100");
@@ -246,40 +240,42 @@ describe("JuiceSwapGateway", function () {
       await jusd.connect(user1).approve(await gateway.getAddress(), swapAmount);
 
       await expect(
-        gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        swapAmount,
-          MIN_OUTPUT,
-          user1.address,
-          pastDeadline
-        )
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            swapAmount,
+            MIN_OUTPUT,
+            user1.address,
+            pastDeadline
+          )
       ).to.be.revertedWithCustomError(gateway, "DeadlineExpired");
     });
 
     it("Should revert if amount is zero", async function () {
-      const { gateway, user1, jusd, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
 
       await expect(
-        gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        0,
-          MIN_OUTPUT,
-          user1.address,
-          deadline
-        )
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            0,
+            MIN_OUTPUT,
+            user1.address,
+            deadline
+          )
       ).to.be.revertedWithCustomError(gateway, "InvalidAmount");
     });
 
     it("Should revert if output is less than minimum", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("100");
@@ -290,21 +286,22 @@ describe("JuiceSwapGateway", function () {
       await jusd.connect(user1).approve(await gateway.getAddress(), swapAmount);
 
       await expect(
-        gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        swapAmount,
-          MIN_OUTPUT,
-          user1.address,
-          deadline
-        )
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            swapAmount,
+            MIN_OUTPUT,
+            user1.address,
+            deadline
+          )
       ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
     });
 
     it("Should automatically convert JUSD to svJUSD for swap", async function () {
-      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("100");
@@ -314,74 +311,331 @@ describe("JuiceSwapGateway", function () {
 
       const svJusdBalanceBefore = await svJusd.balanceOf(await gateway.getAddress());
 
-      await gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        swapAmount,
-        0,
-        user1.address,
-        deadline
-      );
+      await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
 
       // Gateway should have deposited JUSD into svJUSD vault
       // (In real scenario, vault balance changes, but in mock it depends on implementation)
     });
   });
 
-  describe("JUICE Input Restriction", function () {
-    it("Should revert when JUICE is used as input token in swap", async function () {
-      const { gateway, user1, juice, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+  describe("JUICE Input Support", function () {
+    it("Should swap JUICE for WcBTC via redeemFrom", async function () {
+      const { gateway, user1, juice, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
-      const swapAmount = ethers.parseEther("10");
+      const swapAmount = ethers.parseEther("1"); // 1 JUICE
+      const expectedJusd = ethers.parseEther("100"); // 1 JUICE = 100 JUSD (MockEquity PRICE)
+      const expectedWcbtc = ethers.parseEther("0.5");
+
+      // Fund the JUICE contract with JUSD for redemption
+      await jusd.mint(await juice.getAddress(), expectedJusd);
+
+      // Set swap output
+      await swapRouter.setSwapOutput(expectedWcbtc);
 
       await juice.connect(user1).approve(await gateway.getAddress(), swapAmount);
 
-      await expect(
-        gateway.connect(user1).swapExactTokensForTokens(
-        await juice.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        swapAmount,
+      const wcbtcBefore = await wcbtc.balanceOf(user1.address);
+
+      await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await juice.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          swapAmount,
           0,
           user1.address,
           deadline
-        )
-      ).to.be.revertedWithCustomError(gateway, "JuiceInputNotSupported");
+        );
+
+      const wcbtcAfter = await wcbtc.balanceOf(user1.address);
+      expect(wcbtcAfter - wcbtcBefore).to.equal(expectedWcbtc);
     });
 
-    it("Should revert when JUICE is used as input in addLiquidity", async function () {
-      const { gateway, user1, juice, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+    it("Should swap JUICE for JUSD directly", async function () {
+      const { gateway, user1, juice, jusd, svJusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
-      const liquidityAmount = ethers.parseEther("10");
+      const swapAmount = ethers.parseEther("1"); // 1 JUICE
+      const expectedJusd = ethers.parseEther("100"); // 1 JUICE = 100 JUSD
 
-      await juice.connect(user1).approve(await gateway.getAddress(), liquidityAmount);
-      await wcbtc.connect(user1).approve(await gateway.getAddress(), liquidityAmount);
+      // Fund the JUICE contract with JUSD for redemption
+      await jusd.mint(await juice.getAddress(), expectedJusd);
+
+      // For JUICE → JUSD, the swap goes through svJUSD pool
+      // Set swap output to return the svJUSD equivalent
+      const svJusdShares = await svJusd.convertToShares(expectedJusd);
+      await swapRouter.setSwapOutput(svJusdShares);
+
+      await juice.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      const jusdBefore = await jusd.balanceOf(user1.address);
+
+      await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await juice.getAddress(),
+          await jusd.getAddress(),
+          3000,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      const jusdAfter = await jusd.balanceOf(user1.address);
+      // User should receive JUSD (redeemed from svJUSD)
+      expect(jusdAfter).to.be.gt(jusdBefore);
+    });
+
+    it("Should emit SwapExecuted event for JUICE input", async function () {
+      const { gateway, user1, juice, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1");
+      const expectedJusd = ethers.parseEther("100");
+      const expectedWcbtc = ethers.parseEther("0.5");
+
+      await jusd.mint(await juice.getAddress(), expectedJusd);
+      await swapRouter.setSwapOutput(expectedWcbtc);
+      await juice.connect(user1).approve(await gateway.getAddress(), swapAmount);
 
       await expect(
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await juice.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should revert JUICE swap if minAmountOut not met", async function () {
+      const { gateway, user1, juice, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1"); // 1 JUICE
+      const expectedJusd = ethers.parseEther("100");
+      const actualWcbtc = ethers.parseEther("0.5");
+      const unreasonableMinOut = ethers.parseEther("100"); // Way more than we'll get
+
+      await jusd.mint(await juice.getAddress(), expectedJusd);
+      await swapRouter.setSwapOutput(actualWcbtc);
+      await juice.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+      await expect(
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await juice.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            swapAmount,
+            unreasonableMinOut,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+    });
+
+    it("Should revert if JUICE allowance insufficient", async function () {
+      const { gateway, user1, juice, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const swapAmount = ethers.parseEther("1");
+      const expectedJusd = ethers.parseEther("100");
+
+      await jusd.mint(await juice.getAddress(), expectedJusd);
+      await swapRouter.setSwapOutput(ethers.parseEther("0.5"));
+      // NO approval given
+
+      await expect(
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await juice.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(juice, "ERC20InsufficientAllowance");
+    });
+
+    it("Should add liquidity with JUICE as input token (JUICE stays JUICE)", async function () {
+      const { gateway, user1, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const juiceAmount = ethers.parseEther("100"); // 100 JUICE
+      const wcbtcAmount = ethers.parseEther("1");
+
+      // Token ordering: Uniswap V3 requires token0 < token1
+      const juiceAddr = await juice.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = juiceAddr < wcbtcAddr ? [juiceAmount, wcbtcAmount] : [wcbtcAmount, juiceAmount];
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await juice.connect(user1).approve(await gateway.getAddress(), juiceAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Should succeed - JUICE stays as JUICE (not converted to svJUSD)
+      await expect(
         gateway.connect(user1).addLiquidity(
-        await juice.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        liquidityAmount,
-          liquidityAmount,
+          await juice.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0, // tickLower (full range)
+          0, // tickUpper (full range)
+          juiceAmount,
+          wcbtcAmount,
           0,
           0,
           user1.address,
           deadline
         )
-      ).to.be.revertedWithCustomError(gateway, "JuiceInputNotSupported");
+      ).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should return excess as JUICE when adding liquidity with JUICE", async function () {
+      const { gateway, user1, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const juiceAmount = ethers.parseEther("2"); // 2 JUICE (more than needed)
+      const wcbtcAmount = ethers.parseEther("1");
+
+      // Mock position manager to only use half the JUICE
+      const halfJuice = juiceAmount / 2n;
+
+      // Token ordering: Uniswap V3 requires token0 < token1
+      const juiceAddr = await juice.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = juiceAddr < wcbtcAddr ? [halfJuice, wcbtcAmount] : [wcbtcAmount, halfJuice];
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await juice.connect(user1).approve(await gateway.getAddress(), juiceAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      const juiceBefore = await juice.balanceOf(user1.address);
+
+      await gateway.connect(user1).addLiquidity(
+        await juice.getAddress(),
+        await wcbtc.getAddress(),
+        3000,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
+        juiceAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      const juiceAfter = await juice.balanceOf(user1.address);
+      // User should receive excess as JUICE (JUICE stays JUICE for liquidity)
+      // Used half, so should have initial - half remaining
+      expect(juiceBefore - juiceAfter).to.equal(halfJuice);
+    });
+
+    it("Should revert when adding JUICE liquidity with JUSD (invalid pair)", async function () {
+      const { gateway, user1, juice, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      await juice.connect(user1).approve(await gateway.getAddress(), amount);
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // JUICE + JUSD is not allowed (would be redundant with JUICE redemption)
+      await expect(
+        gateway
+          .connect(user1)
+          .addLiquidity(
+            await juice.getAddress(),
+            await jusd.getAddress(),
+            3000,
+            0,
+            0,
+            amount,
+            amount,
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(gateway, "JuiceCannotPairWithUsd");
+    });
+
+    it("Should revert when adding JUICE liquidity with bridged token (invalid pair)", async function () {
+      const { gateway, user1, juice, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy and register a bridged token
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdt = await MockERC20Factory.deploy("USDT.e", "USDT.e", 6);
+      await usdt.waitForDeployment();
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const bridge = await MockBridgeFactory.deploy(
+        await usdt.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"), // limit
+        52 // weeks
+      );
+      await bridge.waitForDeployment();
+
+      // Make bridge an approved minter
+      await jusd.setMinter(await bridge.getAddress(), true);
+      await gateway.registerBridgedToken(await bridge.getAddress());
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      await juice.connect(user1).approve(await gateway.getAddress(), amount);
+      await usdt.mint(user1.address, ethers.parseUnits("100", 6));
+      await usdt.connect(user1).approve(await gateway.getAddress(), ethers.parseUnits("100", 6));
+
+      // JUICE + Bridged token is not allowed
+      await expect(
+        gateway
+          .connect(user1)
+          .addLiquidity(
+            await juice.getAddress(),
+            await usdt.getAddress(),
+            3000,
+            0,
+            0,
+            amount,
+            ethers.parseUnits("100", 6),
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(gateway, "JuiceCannotPairWithUsd");
     });
   });
 
   describe("Swap: Native cBTC", function () {
     it("Should swap native cBTC for tokens", async function () {
-      const { gateway, user1, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("1");
@@ -406,23 +660,22 @@ describe("JuiceSwapGateway", function () {
           ethers.ZeroAddress,
           await wcbtc.getAddress(),
           anyValue, // amountIn
-          anyValue  // amountOut
+          anyValue // amountOut
         );
     });
 
     it("Should revert if msg.value doesn't match amount for native swap", async function () {
-      const { gateway, user1, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("1");
 
       await expect(
         gateway.connect(user1).swapExactTokensForTokens(
-        ethers.ZeroAddress,
-        await wcbtc.getAddress(),
-        3000,
-        swapAmount,
+          ethers.ZeroAddress,
+          await wcbtc.getAddress(),
+          3000,
+          swapAmount,
           0,
           user1.address,
           deadline,
@@ -432,8 +685,7 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should output native cBTC when tokenOut is zero address", async function () {
-      const { gateway, user1, jusd, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("100");
@@ -460,8 +712,7 @@ describe("JuiceSwapGateway", function () {
 
   describe("Swap: WcBTC → JUSD/JUICE", function () {
     it("Should swap WcBTC for JUSD successfully", async function () {
-      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("1");
@@ -474,33 +725,28 @@ describe("JuiceSwapGateway", function () {
 
       const jusdBalanceBefore = await jusd.balanceOf(user1.address);
 
-      const tx = await gateway.connect(user1).swapExactTokensForTokens(
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        3000,
-        swapAmount,
-        MIN_OUTPUT,
-        user1.address,
-        deadline
-      );
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          3000,
+          swapAmount,
+          MIN_OUTPUT,
+          user1.address,
+          deadline
+        );
 
       await expect(tx)
         .to.emit(gateway, "SwapExecuted")
-        .withArgs(
-          user1.address,
-          await wcbtc.getAddress(),
-          await jusd.getAddress(),
-          anyValue,
-          anyValue
-        );
+        .withArgs(user1.address, await wcbtc.getAddress(), await jusd.getAddress(), anyValue, anyValue);
 
       const jusdBalanceAfter = await jusd.balanceOf(user1.address);
       expect(jusdBalanceAfter).to.be.gt(jusdBalanceBefore);
     });
 
     it("Should swap WcBTC for JUICE successfully", async function () {
-      const { gateway, user1, juice, wcbtc, svJusd, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, juice, wcbtc, svJusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("1");
@@ -513,33 +759,28 @@ describe("JuiceSwapGateway", function () {
 
       const juiceBalanceBefore = await juice.balanceOf(user1.address);
 
-      const tx = await gateway.connect(user1).swapExactTokensForTokens(
-        await wcbtc.getAddress(),
-        await juice.getAddress(),
-        3000,
-        swapAmount,
-        MIN_OUTPUT,
-        user1.address,
-        deadline
-      );
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await wcbtc.getAddress(),
+          await juice.getAddress(),
+          3000,
+          swapAmount,
+          MIN_OUTPUT,
+          user1.address,
+          deadline
+        );
 
       await expect(tx)
         .to.emit(gateway, "SwapExecuted")
-        .withArgs(
-          user1.address,
-          await wcbtc.getAddress(),
-          await juice.getAddress(),
-          anyValue,
-          anyValue
-        );
+        .withArgs(user1.address, await wcbtc.getAddress(), await juice.getAddress(), anyValue, anyValue);
 
       const juiceBalanceAfter = await juice.balanceOf(user1.address);
       expect(juiceBalanceAfter).to.be.gt(juiceBalanceBefore);
     });
 
     it("Should swap native cBTC for JUSD successfully", async function () {
-      const { gateway, user1, jusd, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("1");
@@ -563,21 +804,14 @@ describe("JuiceSwapGateway", function () {
 
       await expect(tx)
         .to.emit(gateway, "SwapExecuted")
-        .withArgs(
-          user1.address,
-          ethers.ZeroAddress,
-          await jusd.getAddress(),
-          anyValue,
-          anyValue
-        );
+        .withArgs(user1.address, ethers.ZeroAddress, await jusd.getAddress(), anyValue, anyValue);
 
       const jusdBalanceAfter = await jusd.balanceOf(user1.address);
       expect(jusdBalanceAfter).to.be.gt(jusdBalanceBefore);
     });
 
     it("Should swap native cBTC for JUICE successfully", async function () {
-      const { gateway, user1, juice, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, juice, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("1");
@@ -601,13 +835,7 @@ describe("JuiceSwapGateway", function () {
 
       await expect(tx)
         .to.emit(gateway, "SwapExecuted")
-        .withArgs(
-          user1.address,
-          ethers.ZeroAddress,
-          await juice.getAddress(),
-          anyValue,
-          anyValue
-        );
+        .withArgs(user1.address, ethers.ZeroAddress, await juice.getAddress(), anyValue, anyValue);
 
       const juiceBalanceAfter = await juice.balanceOf(user1.address);
       expect(juiceBalanceAfter).to.be.gt(juiceBalanceBefore);
@@ -616,8 +844,9 @@ describe("JuiceSwapGateway", function () {
 
   describe("Add Liquidity", function () {
     it("Should add liquidity with JUSD successfully", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const jusdAmount = ethers.parseEther("100");
@@ -629,9 +858,10 @@ describe("JuiceSwapGateway", function () {
       // Setup mock position manager with correct token order (token0 < token1)
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares, wcbtcAmount]  // svJUSD is token0
-        : [wcbtcAmount, svJusdShares]; // WcBTC is token0
+      const [amount0, amount1] =
+        svJusdAddr < wcbtcAddr
+          ? [svJusdShares, wcbtcAmount] // svJUSD is token0
+          : [wcbtcAmount, svJusdShares]; // WcBTC is token0
       await positionManager.setMintResult(1, 100, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
@@ -641,6 +871,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         await wcbtc.getAddress(),
         3000,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         jusdAmount,
         wcbtcAmount,
         jusdAmount / 2n,
@@ -657,13 +889,14 @@ describe("JuiceSwapGateway", function () {
           await wcbtc.getAddress(),
           anyValue, // amountA (actual amount added)
           anyValue, // amountB (actual amount added)
-          1  // tokenId from mock
+          1 // tokenId from mock
         );
     });
 
     it("Should convert JUSD to svJUSD when adding liquidity", async function () {
-      const { gateway, user1, jusd, wcbtc, positionManager, svJusd } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, positionManager, svJusd } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const jusdAmount = ethers.parseEther("100");
@@ -675,9 +908,7 @@ describe("JuiceSwapGateway", function () {
       // Setup with correct token order
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares, wcbtcAmount]
-        : [wcbtcAmount, svJusdShares];
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
       await positionManager.setMintResult(1, 100, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
@@ -687,6 +918,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         await wcbtc.getAddress(),
         3000,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         jusdAmount,
         wcbtcAmount,
         0,
@@ -699,8 +932,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should add liquidity with native cBTC", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const jusdAmount = ethers.parseEther("100");
@@ -712,9 +946,7 @@ describe("JuiceSwapGateway", function () {
       // Setup with correct token order (native becomes WcBTC)
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares, cbtcAmount]
-        : [cbtcAmount, svJusdShares];
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, cbtcAmount] : [cbtcAmount, svJusdShares];
       await positionManager.setMintResult(1, 100, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
@@ -723,6 +955,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         ethers.ZeroAddress, // Native cBTC
         3000,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         jusdAmount,
         cbtcAmount,
         0,
@@ -740,13 +974,66 @@ describe("JuiceSwapGateway", function () {
           ethers.ZeroAddress,
           anyValue, // amountA
           anyValue, // amountB
-          1  // tokenId
+          1 // tokenId
         );
     });
 
+    it("Should return excess native cBTC when position manager uses less", async function () {
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const cbtcAmount = ethers.parseEther("2"); // Send 2 cBTC
+
+      // Calculate actual svJUSD shares
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+
+      // Mock position manager to only use HALF the cBTC (simulating excess)
+      const halfCbtc = cbtcAmount / 2n;
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, halfCbtc] : [halfCbtc, svJusdShares];
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+
+      const cbtcBefore = await ethers.provider.getBalance(user1.address);
+
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        ethers.ZeroAddress, // Native cBTC
+        3000,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
+        jusdAmount,
+        cbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline,
+        { value: cbtcAmount }
+      );
+
+      const receipt = await tx.wait();
+      const gasUsed = receipt!.gasUsed * receipt!.gasPrice;
+      const cbtcAfter = await ethers.provider.getBalance(user1.address);
+
+      // User should receive excess cBTC back (sent 2, used 1, got back ~1)
+      // cbtcAfter = cbtcBefore - cbtcAmount + excessReturned - gasUsed
+      // excessReturned ≈ cbtcAmount / 2 = 1 cBTC
+      const expectedSpent = cbtcAmount / 2n; // ~1 cBTC actually used
+      const actualSpent = cbtcBefore - cbtcAfter - gasUsed;
+
+      // Allow some tolerance for gas estimation
+      expect(actualSpent).to.be.closeTo(expectedSpent, ethers.parseEther("0.01"));
+    });
+
     it("Should return excess tokens to user", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const jusdAmount = ethers.parseEther("100");
@@ -758,9 +1045,10 @@ describe("JuiceSwapGateway", function () {
       // Setup with correct token order - mock returns less than desired
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares / 2n, wcbtcAmount / 2n]  // Only half used
-        : [wcbtcAmount / 2n, svJusdShares / 2n];
+      const [amount0, amount1] =
+        svJusdAddr < wcbtcAddr
+          ? [svJusdShares / 2n, wcbtcAmount / 2n] // Only half used
+          : [wcbtcAmount / 2n, svJusdShares / 2n];
       await positionManager.setMintResult(1, 100, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
@@ -772,6 +1060,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         await wcbtc.getAddress(),
         3000,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         jusdAmount,
         wcbtcAmount,
         0,
@@ -787,17 +1077,18 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should revert if deadline expired", async function () {
-      const { gateway, user1, jusd, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const pastDeadline = (await time.latest()) - 1;
 
       await expect(
         gateway.connect(user1).addLiquidity(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        SWAP_AMOUNT,
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0, // tickLower (full range)
+          0, // tickUpper (full range)
+          SWAP_AMOUNT,
           SWAP_AMOUNT,
           0,
           0,
@@ -806,12 +1097,132 @@ describe("JuiceSwapGateway", function () {
         )
       ).to.be.revertedWithCustomError(gateway, "DeadlineExpired");
     });
+
+    it("Should add liquidity with custom tick range", async function () {
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Custom tick range: -60000 to 60000 (aligned to tickSpacing=60 for 0.3% fee)
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        3000, // 0.3% fee tier (tickSpacing=60)
+        -60000, // tickLower (custom)
+        60000, // tickUpper (custom)
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx)
+        .to.emit(gateway, "LiquidityAdded")
+        .withArgs(user1.address, await jusd.getAddress(), await wcbtc.getAddress(), anyValue, anyValue, 1);
+    });
+
+    it("Should revert with InvalidTickRange when tickLower >= tickUpper (non-equal)", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          60000, // tickLower > tickUpper
+          -60000,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
+
+    it("Should revert with InvalidTickRange when ticks not aligned to tickSpacing", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // tickSpacing for 3000 (0.3%) is 60, so 60001 is not aligned
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          -60001, // Not aligned to tickSpacing=60
+          60000,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
+
+    it("Should revert with InvalidTickRange when ticks out of bounds", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // MAX_TICK is 887272, aligned to 60 would be 887220
+      // Using 887280 which is > 887272
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          -887220,
+          887280, // Out of bounds (> 887272)
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
   });
 
   describe("Increase Liquidity", function () {
     it("Should increase liquidity successfully", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -821,9 +1232,7 @@ describe("JuiceSwapGateway", function () {
       // Setup position with svJUSD and WcBTC in correct address ordering
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       // Mint NFT to user and approve gateway
@@ -835,34 +1244,35 @@ describe("JuiceSwapGateway", function () {
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
       // Call with WcBTC first to avoid token ordering edge case
-      const tx = await gateway.connect(user1).increaseLiquidity(
-        tokenId,
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        wcbtcAmount,
-        jusdAmount,
-        0,
-        0,
-        deadline
-      );
-
-      await expect(tx)
-        .to.emit(gateway, "LiquidityIncreased")
-        .withArgs(
-          user1.address,
+      const tx = await gateway
+        .connect(user1)
+        .increaseLiquidity(
           tokenId,
-          anyValue, // amountA
-          anyValue, // amountB
-          anyValue  // liquidity
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          wcbtcAmount,
+          jusdAmount,
+          0,
+          0,
+          deadline
         );
+
+      await expect(tx).to.emit(gateway, "LiquidityIncreased").withArgs(
+        user1.address,
+        tokenId,
+        anyValue, // amountA
+        anyValue, // amountB
+        anyValue // liquidity
+      );
 
       // Verify NFT returned to user
       expect(await positionManager.ownerOf(tokenId)).to.equal(user1.address);
     });
 
     it("Should convert JUSD to svJUSD when increasing liquidity", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -871,9 +1281,7 @@ describe("JuiceSwapGateway", function () {
 
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       await positionManager.mintNFT(user1.address, tokenId);
@@ -885,16 +1293,18 @@ describe("JuiceSwapGateway", function () {
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
       // Call with WcBTC first
-      await gateway.connect(user1).increaseLiquidity(
-        tokenId,
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        wcbtcAmount,
-        jusdAmount,
-        0,
-        0,
-        deadline
-      );
+      await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          tokenId,
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          wcbtcAmount,
+          jusdAmount,
+          0,
+          0,
+          deadline
+        );
 
       const jusdBalanceAfter = await jusd.balanceOf(user1.address);
       // JUSD balance should decrease (converted to svJUSD)
@@ -902,8 +1312,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should wrap native cBTC when increasing liquidity", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -912,9 +1323,7 @@ describe("JuiceSwapGateway", function () {
 
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       await positionManager.mintNFT(user1.address, tokenId);
@@ -941,8 +1350,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should handle tokenA < tokenB ordering", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -953,9 +1363,7 @@ describe("JuiceSwapGateway", function () {
       const wcbtcAddr = await wcbtc.getAddress();
 
       // Set position with correct address ordering
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       await positionManager.mintNFT(user1.address, tokenId);
@@ -965,24 +1373,26 @@ describe("JuiceSwapGateway", function () {
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
       // Call with WcBTC first (to match token ordering expectation)
-      const tx = await gateway.connect(user1).increaseLiquidity(
-        tokenId,
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        wcbtcAmount,
-        jusdAmount,
-        0,
-        0,
-        deadline
-      );
+      const tx = await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          tokenId,
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          wcbtcAmount,
+          jusdAmount,
+          0,
+          0,
+          deadline
+        );
 
-      await expect(tx)
-        .to.emit(gateway, "LiquidityIncreased");
+      await expect(tx).to.emit(gateway, "LiquidityIncreased");
     });
 
     it("Should handle tokenB < tokenA ordering", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -993,9 +1403,7 @@ describe("JuiceSwapGateway", function () {
       const wcbtcAddr = await wcbtc.getAddress();
 
       // Set position with correct address ordering
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       // Don't set mock values - let it default to using desired amounts
@@ -1007,24 +1415,26 @@ describe("JuiceSwapGateway", function () {
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
       // Call with WcBTC, JUSD order (reversed)
-      const tx = await gateway.connect(user1).increaseLiquidity(
-        tokenId,
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        wcbtcAmount,
-        jusdAmount,
-        0,
-        0,
-        deadline
-      );
+      const tx = await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          tokenId,
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          wcbtcAmount,
+          jusdAmount,
+          0,
+          0,
+          deadline
+        );
 
-      await expect(tx)
-        .to.emit(gateway, "LiquidityIncreased");
+      await expect(tx).to.emit(gateway, "LiquidityIncreased");
     });
 
     it("Should return excess tokens to user", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1033,9 +1443,7 @@ describe("JuiceSwapGateway", function () {
 
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       await positionManager.mintNFT(user1.address, tokenId);
@@ -1047,16 +1455,18 @@ describe("JuiceSwapGateway", function () {
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
       // Call with WcBTC first
-      await gateway.connect(user1).increaseLiquidity(
-        tokenId,
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        wcbtcAmount,
-        jusdAmount,
-        0,
-        0,
-        deadline
-      );
+      await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          tokenId,
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          wcbtcAmount,
+          jusdAmount,
+          0,
+          0,
+          deadline
+        );
 
       const jusdBalanceAfter = await jusd.balanceOf(user1.address);
       // JUSD should decrease by approximately the input amount
@@ -1064,8 +1474,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should revert if non-owner tries to increase liquidity", async function () {
-      const { gateway, user1, user2, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, user2, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1084,22 +1495,25 @@ describe("JuiceSwapGateway", function () {
 
       // user2 tries to increase liquidity on user1's NFT
       await expect(
-        gateway.connect(user2).increaseLiquidity(
-          tokenId,
-          await jusd.getAddress(),
-          await wcbtc.getAddress(),
-          jusdAmount,
-          wcbtcAmount,
-          0,
-          0,
-          deadline
-        )
+        gateway
+          .connect(user2)
+          .increaseLiquidity(
+            tokenId,
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            jusdAmount,
+            wcbtcAmount,
+            0,
+            0,
+            deadline
+          )
       ).to.be.revertedWithCustomError(gateway, "NotNFTOwner");
     });
 
     it("Should return NFT to user after operation", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1108,9 +1522,7 @@ describe("JuiceSwapGateway", function () {
 
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       await positionManager.mintNFT(user1.address, tokenId);
@@ -1123,24 +1535,27 @@ describe("JuiceSwapGateway", function () {
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
       // Call with WcBTC first
-      await gateway.connect(user1).increaseLiquidity(
-        tokenId,
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        wcbtcAmount,
-        jusdAmount,
-        0,
-        0,
-        deadline
-      );
+      await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          tokenId,
+          await wcbtc.getAddress(),
+          await jusd.getAddress(),
+          wcbtcAmount,
+          jusdAmount,
+          0,
+          0,
+          deadline
+        );
 
       // Verify ownership after
       expect(await positionManager.ownerOf(tokenId)).to.equal(user1.address);
     });
 
     it("Should revert if deadline expired", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const pastDeadline = (await time.latest()) - 1;
       const tokenId = 1;
@@ -1153,22 +1568,25 @@ describe("JuiceSwapGateway", function () {
       await positionManager.mintNFT(user1.address, tokenId);
 
       await expect(
-        gateway.connect(user1).increaseLiquidity(
-          tokenId,
-          await jusd.getAddress(),
-          await wcbtc.getAddress(),
-          jusdAmount,
-          wcbtcAmount,
-          0,
-          0,
-          pastDeadline
-        )
+        gateway
+          .connect(user1)
+          .increaseLiquidity(
+            tokenId,
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            jusdAmount,
+            wcbtcAmount,
+            0,
+            0,
+            pastDeadline
+          )
       ).to.be.revertedWithCustomError(gateway, "DeadlineExpired");
     });
 
     it("Should emit LiquidityIncreased with correct parameters", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 42; // Use specific tokenId
@@ -1177,9 +1595,7 @@ describe("JuiceSwapGateway", function () {
 
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       await positionManager.mintNFT(user1.address, tokenId);
@@ -1189,81 +1605,50 @@ describe("JuiceSwapGateway", function () {
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
       // Call with WcBTC first
-      const tx = await gateway.connect(user1).increaseLiquidity(
-        tokenId,
-        await wcbtc.getAddress(),
-        await jusd.getAddress(),
-        wcbtcAmount,
-        jusdAmount,
-        0,
-        0,
-        deadline
-      );
-
-      await expect(tx)
-        .to.emit(gateway, "LiquidityIncreased")
-        .withArgs(
-          user1.address,
+      const tx = await gateway
+        .connect(user1)
+        .increaseLiquidity(
           tokenId,
-          anyValue, // amountA
-          anyValue, // amountB
-          100       // default liquidity from mock
-        );
-    });
-
-    it("Should revert when paused", async function () {
-      const { gateway, owner, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
-
-      const deadline = (await time.latest()) + DEADLINE_OFFSET;
-      const tokenId = 1;
-      const jusdAmount = ethers.parseEther("100");
-      const wcbtcAmount = ethers.parseEther("1");
-
-      const svJusdAddr = await svJusd.getAddress();
-      const wcbtcAddr = await wcbtc.getAddress();
-      await positionManager.setPositionData(tokenId, svJusdAddr, wcbtcAddr, 100);
-      await positionManager.mintNFT(user1.address, tokenId);
-      await positionManager.connect(user1).approve(await gateway.getAddress(), tokenId);
-
-      // Pause the contract
-      await gateway.connect(owner).pause();
-
-      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
-      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
-
-      await expect(
-        gateway.connect(user1).increaseLiquidity(
-          tokenId,
-          await jusd.getAddress(),
           await wcbtc.getAddress(),
-          jusdAmount,
+          await jusd.getAddress(),
           wcbtcAmount,
+          jusdAmount,
           0,
           0,
           deadline
-        )
-      ).to.be.revertedWithCustomError(gateway, "EnforcedPause");
+        );
+
+      await expect(tx).to.emit(gateway, "LiquidityIncreased").withArgs(
+        user1.address,
+        tokenId,
+        anyValue, // amountA
+        anyValue, // amountB
+        100 // default liquidity from mock
+      );
     });
 
-    it("Should revert when JUICE is used as input token", async function () {
-      const { gateway, user1, juice, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+    it("Should increase liquidity with JUICE as input token (JUICE stays JUICE)", async function () {
+      const { gateway, user1, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
-      const juiceAmount = ethers.parseEther("100");
+      const juiceAmount = ethers.parseEther("100"); // 100 JUICE
       const wcbtcAmount = ethers.parseEther("1");
 
-      const svJusdAddr = await svJusd.getAddress();
+      const juiceAddr = await juice.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      await positionManager.setPositionData(tokenId, svJusdAddr, wcbtcAddr, 100);
+
+      // Token ordering: Uniswap V3 requires token0 < token1
+      // Position is JUICE/WcBTC (JUICE stays JUICE for liquidity)
+      const [token0, token1] = juiceAddr < wcbtcAddr ? [juiceAddr, wcbtcAddr] : [wcbtcAddr, juiceAddr];
+      await positionManager.setPositionData(tokenId, token0, token1, 100);
       await positionManager.mintNFT(user1.address, tokenId);
       await positionManager.connect(user1).approve(await gateway.getAddress(), tokenId);
 
       await juice.connect(user1).approve(await gateway.getAddress(), juiceAmount);
       await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
 
+      // Should succeed - JUICE stays as JUICE (not converted to svJUSD)
       await expect(
         gateway.connect(user1).increaseLiquidity(
           tokenId,
@@ -1275,12 +1660,13 @@ describe("JuiceSwapGateway", function () {
           0,
           deadline
         )
-      ).to.be.revertedWithCustomError(gateway, "JuiceInputNotSupported");
+      ).to.not.be.reverted;
     });
 
     it("Should revert if tokens don't match position", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1291,9 +1677,7 @@ describe("JuiceSwapGateway", function () {
       const wcbtcAddr = await wcbtc.getAddress();
 
       // Setup position with svJUSD/WcBTC tokens
-      const [token0, token1] = svJusdAddr < wcbtcAddr
-        ? [svJusdAddr, wcbtcAddr]
-        : [wcbtcAddr, svJusdAddr];
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
       await positionManager.setPositionData(tokenId, token0, token1, 100);
 
       await positionManager.mintNFT(user1.address, tokenId);
@@ -1320,7 +1704,8 @@ describe("JuiceSwapGateway", function () {
           0,
           deadline
         )
-      ).to.be.revertedWithCustomError(gateway, "TokenMismatch")
+      )
+        .to.be.revertedWithCustomError(gateway, "TokenMismatch")
         .withArgs(token0, token1, await wrongToken.getAddress(), wcbtcAddr);
 
       // Verify NFT remains with user (validation happens before NFT transfer)
@@ -1330,8 +1715,9 @@ describe("JuiceSwapGateway", function () {
 
   describe("Remove Liquidity", function () {
     it("Should remove liquidity successfully", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1347,7 +1733,7 @@ describe("JuiceSwapGateway", function () {
       );
       await positionManager.setDecreaseResult(
         ethers.parseEther("100"), // svJUSD shares
-        ethers.parseEther("100")  // WcBTC (increased to match test expectations)
+        ethers.parseEther("100") // WcBTC (increased to match test expectations)
       );
 
       // Fund position manager with tokens it will return
@@ -1382,13 +1768,14 @@ describe("JuiceSwapGateway", function () {
           await wcbtc.getAddress(),
           anyValue, // amountA
           anyValue, // amountB
-          tokenId  // tokenId = 1
+          tokenId // tokenId = 1
         );
     });
 
     it("Should convert svJUSD back to JUSD when removing liquidity", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1400,10 +1787,7 @@ describe("JuiceSwapGateway", function () {
         await wcbtc.getAddress(),
         liquidity
       );
-      await positionManager.setDecreaseResult(
-        ethers.parseEther("100"),
-        ethers.parseEther("100")
-      );
+      await positionManager.setDecreaseResult(ethers.parseEther("100"), ethers.parseEther("100"));
 
       // Fund position manager
       const posManagerAddr = await positionManager.getAddress();
@@ -1435,8 +1819,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should output native cBTC when removing liquidity", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1449,10 +1834,7 @@ describe("JuiceSwapGateway", function () {
         await wcbtc.getAddress(), // WcBTC (not native)
         liquidity
       );
-      await positionManager.setDecreaseResult(
-        ethers.parseEther("100"),
-        ethers.parseEther("100")
-      );
+      await positionManager.setDecreaseResult(ethers.parseEther("100"), ethers.parseEther("100"));
 
       // Fund position manager
       const posManagerAddr = await positionManager.getAddress();
@@ -1484,8 +1866,7 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should revert if deadline expired", async function () {
-      const { gateway, user1, jusd, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const pastDeadline = (await time.latest()) - 1;
       const tokenId = 1;
@@ -1505,8 +1886,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should revert when JUICE output is less than minimum after conversion (JUICE1-4)", async function () {
-      const { gateway, user1, juice, svJusd, wcbtc, positionManager, jusd } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, juice, svJusd, wcbtc, positionManager, jusd } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1572,8 +1954,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should remove partial liquidity (liquidityToRemove > 0)", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1616,22 +1999,16 @@ describe("JuiceSwapGateway", function () {
 
       await expect(tx)
         .to.emit(gateway, "LiquidityRemoved")
-        .withArgs(
-          user1.address,
-          await jusd.getAddress(),
-          await wcbtc.getAddress(),
-          anyValue,
-          anyValue,
-          tokenId
-        );
+        .withArgs(user1.address, await jusd.getAddress(), await wcbtc.getAddress(), anyValue, anyValue, tokenId);
 
       // NFT should still be owned by user (not burned)
       expect(await positionManager.ownerOf(tokenId)).to.equal(user1.address);
     });
 
     it("Should remove all liquidity when liquidityToRemove = 0", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1675,14 +2052,7 @@ describe("JuiceSwapGateway", function () {
 
       await expect(tx)
         .to.emit(gateway, "LiquidityRemoved")
-        .withArgs(
-          user1.address,
-          await jusd.getAddress(),
-          await wcbtc.getAddress(),
-          anyValue,
-          anyValue,
-          tokenId
-        );
+        .withArgs(user1.address, await jusd.getAddress(), await wcbtc.getAddress(), anyValue, anyValue, tokenId);
 
       const jusdBalanceAfter = await jusd.balanceOf(user1.address);
       // User should receive JUSD from liquidity removal
@@ -1693,8 +2063,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should revert if liquidityToRemove exceeds position liquidity", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1724,29 +2095,119 @@ describe("JuiceSwapGateway", function () {
           user1.address,
           deadline
         )
-      ).to.be.revertedWithCustomError(gateway, "InsufficientLiquidity")
+      )
+        .to.be.revertedWithCustomError(gateway, "InsufficientLiquidity")
         .withArgs(liquidityToRemove, positionLiquidity);
+    });
+
+    it("Should remove JUICE liquidity successfully (JUICE transferred directly)", async function () {
+      const { gateway, user1, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const tokenId = 1;
+      const liquidity = 100;
+      const juiceAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const juiceAddr = await juice.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Token ordering: Uniswap V3 requires token0 < token1
+      // For JUICE liquidity pools, JUICE stays as JUICE (not converted to svJUSD)
+      const [token0, token1] = juiceAddr < wcbtcAddr ? [juiceAddr, wcbtcAddr] : [wcbtcAddr, juiceAddr];
+      const isJuiceToken0 = juiceAddr < wcbtcAddr;
+
+      await positionManager.setPositionData(tokenId, token0, token1, liquidity);
+      await positionManager.setDecreaseResult(
+        isJuiceToken0 ? juiceAmount : wcbtcAmount,
+        isJuiceToken0 ? wcbtcAmount : juiceAmount
+      );
+
+      // Fund position manager with JUICE and WcBTC (NOT svJUSD!)
+      const posManagerAddr = await positionManager.getAddress();
+      await juice.mint(posManagerAddr, juiceAmount);
+      await wcbtc.deposit({ value: wcbtcAmount });
+      await wcbtc.transfer(posManagerAddr, wcbtcAmount);
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(await gateway.getAddress(), tokenId);
+
+      const juiceBalanceBefore = await juice.balanceOf(user1.address);
+      const wcbtcBalanceBefore = await wcbtc.balanceOf(user1.address);
+
+      const tx = await gateway.connect(user1).removeLiquidity(
+        tokenId,
+        0, // Remove all liquidity
+        await juice.getAddress(),
+        await wcbtc.getAddress(),
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx)
+        .to.emit(gateway, "LiquidityRemoved")
+        .withArgs(user1.address, await juice.getAddress(), await wcbtc.getAddress(), anyValue, anyValue, tokenId);
+
+      // User should receive JUICE directly (not converted from svJUSD)
+      const juiceBalanceAfter = await juice.balanceOf(user1.address);
+      const wcbtcBalanceAfter = await wcbtc.balanceOf(user1.address);
+
+      expect(juiceBalanceAfter).to.be.gt(juiceBalanceBefore);
+      expect(wcbtcBalanceAfter).to.be.gt(wcbtcBalanceBefore);
+
+      // NFT should still be owned by user
+      expect(await positionManager.ownerOf(tokenId)).to.equal(user1.address);
+    });
+
+    it("Should revert when removeLiquidity tokens don't match position", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, juice, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const tokenId = 1;
+      const liquidity = 100;
+
+      const juiceAddr = await juice.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Create a JUICE/WcBTC position (JUICE liquidity pool)
+      const [token0, token1] = juiceAddr < wcbtcAddr ? [juiceAddr, wcbtcAddr] : [wcbtcAddr, juiceAddr];
+      await positionManager.setPositionData(tokenId, token0, token1, liquidity);
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(await gateway.getAddress(), tokenId);
+
+      // Try to remove with wrong tokens (JUSD/WcBTC instead of JUICE/WcBTC)
+      // For JUICE pools, _getActualTokenForLiquidity(JUSD) returns svJUSD
+      // But the position has JUICE, not svJUSD, so TokenMismatch should be raised
+      await expect(
+        gateway.connect(user1).removeLiquidity(
+          tokenId,
+          0,
+          await jusd.getAddress(), // Wrong token - position has JUICE, not svJUSD
+          await wcbtc.getAddress(),
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "TokenMismatch");
     });
   });
 
   describe("NFT Handling", function () {
     it("Should return NFT to user after removing liquidity", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
 
-      await positionManager.setPositionData(
-        tokenId,
-        await svJusd.getAddress(),
-        await wcbtc.getAddress(),
-        100
-      );
-      await positionManager.setDecreaseResult(
-        ethers.parseEther("100"),
-        ethers.parseEther("100")
-      );
+      await positionManager.setPositionData(tokenId, await svJusd.getAddress(), await wcbtc.getAddress(), 100);
+      await positionManager.setDecreaseResult(ethers.parseEther("100"), ethers.parseEther("100"));
 
       const posManagerAddr = await positionManager.getAddress();
       const [owner] = await ethers.getSigners();
@@ -1774,8 +2235,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should revert if non-owner tries to remove liquidity", async function () {
-      const { gateway, user1, user2, jusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, user2, jusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 1;
@@ -1794,148 +2256,6 @@ describe("JuiceSwapGateway", function () {
           deadline
         )
       ).to.be.revertedWithCustomError(gateway, "NotNFTOwner");
-    });
-  });
-
-  describe("Admin Functions", function () {
-    it("Should allow owner to set default fee", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-
-      const newFee = 500; // 0.05%
-      await expect(gateway.connect(owner).setDefaultFee(newFee))
-        .to.emit(gateway, "DefaultFeeUpdated")
-        .withArgs(3000, newFee);
-
-      expect(await gateway.defaultFee()).to.equal(newFee);
-    });
-
-    it("Should not allow non-owner to set default fee", async function () {
-      const { gateway, user1 } = await loadFixture(deployGatewayFixture);
-
-      await expect(
-        gateway.connect(user1).setDefaultFee(500)
-      ).to.be.revertedWithCustomError(gateway, "OwnableUnauthorizedAccount");
-    });
-
-    it("Should accept valid standard fee tiers", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-
-      await expect(gateway.connect(owner).setDefaultFee(100)).to.not.be.reverted;
-      await expect(gateway.connect(owner).setDefaultFee(500)).to.not.be.reverted;
-      await expect(gateway.connect(owner).setDefaultFee(3000)).to.not.be.reverted;
-      await expect(gateway.connect(owner).setDefaultFee(10000)).to.not.be.reverted;
-    });
-
-    it("Should reject fee tiers not enabled in factory", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-
-      // Fee tier 2000 is not a standard Uniswap V3 fee tier (100, 500, 3000, 10000)
-      await expect(
-        gateway.connect(owner).setDefaultFee(2000)
-      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
-
-      // Fee tier 999999 is also not enabled in factory
-      await expect(
-        gateway.connect(owner).setDefaultFee(999999)
-      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
-    });
-
-    it("Should reject fee tiers >= 1,000,000", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-
-      await expect(
-        gateway.connect(owner).setDefaultFee(1_000_000)
-      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
-
-      await expect(
-        gateway.connect(owner).setDefaultFee(2_000_000)
-      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
-    });
-
-    it("Should allow owner to pause", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-
-      await gateway.connect(owner).pause();
-      expect(await gateway.paused()).to.be.true;
-    });
-
-    it("Should allow owner to unpause", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-
-      await gateway.connect(owner).pause();
-      await gateway.connect(owner).unpause();
-      expect(await gateway.paused()).to.be.false;
-    });
-
-    it("Should not allow non-owner to pause", async function () {
-      const { gateway, user1 } = await loadFixture(deployGatewayFixture);
-
-      await expect(
-        gateway.connect(user1).pause()
-      ).to.be.revertedWithCustomError(gateway, "OwnableUnauthorizedAccount");
-    });
-
-    it("Should block swaps when paused", async function () {
-      const { gateway, owner, user1, jusd, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
-
-      await gateway.connect(owner).pause();
-
-      const deadline = (await time.latest()) + DEADLINE_OFFSET;
-      await jusd.connect(user1).approve(await gateway.getAddress(), SWAP_AMOUNT);
-
-      await expect(
-        gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        SWAP_AMOUNT,
-          0,
-          user1.address,
-          deadline
-        )
-      ).to.be.revertedWithCustomError(gateway, "EnforcedPause");
-    });
-
-    it("Should allow owner to rescue native tokens", async function () {
-      const { gateway, owner } = await loadFixture(deployGatewayFixture);
-
-      // Note: Gateway blocks direct transfers via receive(), so native tokens
-      // can only get stuck through wrapped token operations
-      // This test just verifies the rescue function can be called successfully
-      // Event is only emitted if balance > 0
-      await expect(gateway.connect(owner).rescueNative()).to.not.be.reverted;
-    });
-
-    it("Should allow owner to rescue ERC20 tokens", async function () {
-      const { gateway, owner, jusd } = await loadFixture(deployGatewayFixture);
-
-      const rescueAmount = ethers.parseEther("100");
-      await jusd.mint(await gateway.getAddress(), rescueAmount);
-
-      await expect(
-        gateway.connect(owner).rescueToken(
-          await jusd.getAddress(),
-          owner.address,
-          rescueAmount
-        )
-      )
-        .to.emit(gateway, "TokenRescued")
-        .withArgs(await jusd.getAddress(), owner.address, rescueAmount);
-
-      expect(await jusd.balanceOf(owner.address)).to.equal(rescueAmount);
-    });
-
-    it("Should not allow rescuing tokens to zero address", async function () {
-      const { gateway, owner, jusd } = await loadFixture(deployGatewayFixture);
-
-      await expect(
-        gateway.connect(owner).rescueToken(
-          await jusd.getAddress(),
-          ethers.ZeroAddress,
-          ethers.parseEther("100")
-        )
-      ).to.be.revertedWithCustomError(gateway, "InvalidToken");
     });
   });
 
@@ -1965,8 +2285,7 @@ describe("JuiceSwapGateway", function () {
 
   describe("Edge Cases", function () {
     it("Should handle very small amounts", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tinyAmount = 1n; // 1 wei
@@ -1975,15 +2294,17 @@ describe("JuiceSwapGateway", function () {
       await jusd.connect(user1).approve(await gateway.getAddress(), tinyAmount);
 
       // Should not revert
-      await gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        tinyAmount,
-        0,
-        user1.address,
-        deadline
-      );
+      await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          tinyAmount,
+          0,
+          user1.address,
+          deadline
+        );
     });
 
     it("Should handle maximum uint256 approvals", async function () {
@@ -1997,8 +2318,7 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should handle token order correctly (token0 < token1)", async function () {
-      const { gateway, user1, jusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
 
@@ -2017,6 +2337,8 @@ describe("JuiceSwapGateway", function () {
           jusdAddr,
           wcbtcAddr,
           3000,
+          0, // tickLower (full range)
+          0, // tickUpper (full range)
           SWAP_AMOUNT,
           SWAP_AMOUNT,
           0,
@@ -2029,6 +2351,8 @@ describe("JuiceSwapGateway", function () {
           wcbtcAddr,
           jusdAddr,
           3000,
+          0, // tickLower (full range)
+          0, // tickUpper (full range)
           SWAP_AMOUNT,
           SWAP_AMOUNT,
           0,
@@ -2042,8 +2366,7 @@ describe("JuiceSwapGateway", function () {
 
   describe("Gas Optimization", function () {
     it("Should use pre-approved tokens efficiently", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
 
@@ -2051,26 +2374,30 @@ describe("JuiceSwapGateway", function () {
       await jusd.connect(user1).approve(await gateway.getAddress(), SWAP_AMOUNT);
 
       // First swap
-      const tx1 = await gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        SWAP_AMOUNT / 2n,
-        0,
-        user1.address,
-        deadline
-      );
+      const tx1 = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          SWAP_AMOUNT / 2n,
+          0,
+          user1.address,
+          deadline
+        );
 
       // Second swap should not require additional approvals internally
-      const tx2 = await gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        SWAP_AMOUNT / 2n,
-        0,
-        user1.address,
-        deadline
-      );
+      const tx2 = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          SWAP_AMOUNT / 2n,
+          0,
+          user1.address,
+          deadline
+        );
 
       // Gas should be similar (no approval overhead)
       const receipt1 = await tx1.wait();
@@ -2083,8 +2410,7 @@ describe("JuiceSwapGateway", function () {
 
   describe("Fee Tier Validation", function () {
     it("Should revert swap with fee >= 1,000,000", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("10");
@@ -2106,8 +2432,7 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should revert addLiquidity with unsupported fee tier", async function () {
-      const { gateway, user1, jusd, wcbtc } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const amount = ethers.parseEther("10");
@@ -2120,6 +2445,8 @@ describe("JuiceSwapGateway", function () {
           await jusd.getAddress(),
           await wcbtc.getAddress(),
           2500, // Not in factory
+          0, // tickLower (full range)
+          0, // tickUpper (full range)
           amount,
           amount,
           0,
@@ -2169,8 +2496,7 @@ describe("JuiceSwapGateway", function () {
 
   describe("Multiple Fee Tier Support", function () {
     it("Should swap with 0.01% fee tier (100)", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("10");
@@ -2194,8 +2520,7 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should swap with 0.05% fee tier (500)", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("10");
@@ -2219,8 +2544,7 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should swap with 1% fee tier (10000)", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("10");
@@ -2244,8 +2568,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should add liquidity with 0.01% fee tier (100)", async function () {
-      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const amount = ethers.parseEther("10");
@@ -2253,9 +2578,7 @@ describe("JuiceSwapGateway", function () {
       const svJusdShares = await svJusd.convertToShares(amount);
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares, amount]
-        : [amount, svJusdShares];
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
       await positionManager.setMintResult(1, 100, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), amount);
@@ -2265,6 +2588,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         await wcbtc.getAddress(),
         100, // 0.01% fee tier
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         amount,
         amount,
         0,
@@ -2279,8 +2604,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should add liquidity with 0.05% fee tier (500)", async function () {
-      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const amount = ethers.parseEther("10");
@@ -2288,9 +2614,7 @@ describe("JuiceSwapGateway", function () {
       const svJusdShares = await svJusd.convertToShares(amount);
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares, amount]
-        : [amount, svJusdShares];
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
       await positionManager.setMintResult(1, 100, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), amount);
@@ -2300,6 +2624,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         await wcbtc.getAddress(),
         500, // 0.05% fee tier
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         amount,
         amount,
         0,
@@ -2314,8 +2640,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should add liquidity with 1% fee tier (10000)", async function () {
-      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const amount = ethers.parseEther("10");
@@ -2323,9 +2650,7 @@ describe("JuiceSwapGateway", function () {
       const svJusdShares = await svJusd.convertToShares(amount);
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares, amount]
-        : [amount, svJusdShares];
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
       await positionManager.setMintResult(1, 100, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), amount);
@@ -2335,6 +2660,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         await wcbtc.getAddress(),
         10000, // 1% fee tier
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         amount,
         amount,
         0,
@@ -2351,8 +2678,7 @@ describe("JuiceSwapGateway", function () {
 
   describe("Event Parameter Validation", function () {
     it("Should emit SwapExecuted with all correct parameters", async function () {
-      const { gateway, user1, jusd, wcbtc, swapRouter } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const swapAmount = ethers.parseEther("10");
@@ -2361,15 +2687,17 @@ describe("JuiceSwapGateway", function () {
       await swapRouter.setSwapOutput(expectedOutput);
       await jusd.connect(user1).approve(await gateway.getAddress(), swapAmount);
 
-      const tx = await gateway.connect(user1).swapExactTokensForTokens(
-        await jusd.getAddress(),
-        await wcbtc.getAddress(),
-        3000,
-        swapAmount,
-        0,
-        user1.address,
-        deadline
-      );
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          swapAmount,
+          0,
+          user1.address,
+          deadline
+        );
 
       await expect(tx)
         .to.emit(gateway, "SwapExecuted")
@@ -2383,8 +2711,9 @@ describe("JuiceSwapGateway", function () {
     });
 
     it("Should emit LiquidityAdded with correct tokenId (not liquidity amount)", async function () {
-      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const amount = ethers.parseEther("10");
@@ -2393,9 +2722,7 @@ describe("JuiceSwapGateway", function () {
       const svJusdShares = await svJusd.convertToShares(amount);
       const svJusdAddr = await svJusd.getAddress();
       const wcbtcAddr = await wcbtc.getAddress();
-      const [amount0, amount1] = svJusdAddr < wcbtcAddr
-        ? [svJusdShares, amount]
-        : [amount, svJusdShares];
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
       await positionManager.setMintResult(expectedTokenId, 999, amount0, amount1);
 
       await jusd.connect(user1).approve(await gateway.getAddress(), amount);
@@ -2405,6 +2732,8 @@ describe("JuiceSwapGateway", function () {
         await jusd.getAddress(),
         await wcbtc.getAddress(),
         3000,
+        0, // tickLower (full range)
+        0, // tickUpper (full range)
         amount,
         amount,
         0,
@@ -2422,28 +2751,21 @@ describe("JuiceSwapGateway", function () {
           await wcbtc.getAddress(),
           anyValue,
           anyValue,
-          expectedTokenId  // This is the NFT tokenId, NOT the liquidity amount
+          expectedTokenId // This is the NFT tokenId, NOT the liquidity amount
         );
     });
 
     it("Should emit LiquidityRemoved with correct tokenId", async function () {
-      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } =
-        await loadFixture(deployGatewayWithBalancesFixture);
+      const { gateway, user1, jusd, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
 
       const deadline = (await time.latest()) + DEADLINE_OFFSET;
       const tokenId = 7; // Use specific tokenId
       const liquidity = 100;
 
-      await positionManager.setPositionData(
-        tokenId,
-        await svJusd.getAddress(),
-        await wcbtc.getAddress(),
-        liquidity
-      );
-      await positionManager.setDecreaseResult(
-        ethers.parseEther("10"),
-        ethers.parseEther("10")
-      );
+      await positionManager.setPositionData(tokenId, await svJusd.getAddress(), await wcbtc.getAddress(), liquidity);
+      await positionManager.setDecreaseResult(ethers.parseEther("10"), ethers.parseEther("10"));
 
       const posManagerAddr = await positionManager.getAddress();
       const [owner] = await ethers.getSigners();
@@ -2475,7 +2797,7 @@ describe("JuiceSwapGateway", function () {
           await wcbtc.getAddress(),
           anyValue,
           anyValue,
-          tokenId  // Verify correct tokenId is emitted
+          tokenId // Verify correct tokenId is emitted
         );
     });
   });
@@ -2495,10 +2817,18 @@ describe("JuiceSwapGateway", function () {
       const jusd = (await MockERC20Factory.deploy("JuiceDollar", "JUSD", 18)) as unknown as MockERC20;
 
       const MockEquityFactory = await ethers.getContractFactory("MockEquity");
-      const juice = (await MockEquityFactory.deploy("Juice Protocol", "JUICE", await jusd.getAddress())) as unknown as MockEquity;
+      const juice = (await MockEquityFactory.deploy(
+        "Juice Protocol",
+        "JUICE",
+        await jusd.getAddress()
+      )) as unknown as MockEquity;
 
       const MockERC4626Factory = await ethers.getContractFactory("MockERC4626");
-      const svJusd = (await MockERC4626Factory.deploy(await jusd.getAddress(), "Savings Vault JUSD", "svJUSD")) as unknown as MockERC4626;
+      const svJusd = (await MockERC4626Factory.deploy(
+        await jusd.getAddress(),
+        "Savings Vault JUSD",
+        "svJUSD"
+      )) as unknown as MockERC4626;
 
       const MockWETHFactory = await ethers.getContractFactory("MockWETH");
       const wcbtc = (await MockWETHFactory.deploy("Wrapped cBTC", "WcBTC")) as unknown as MockWETH;
@@ -2567,10 +2897,15 @@ describe("JuiceSwapGateway", function () {
       await usdt.mint(user1.address, userAmount);
       await ctUsd.mint(user1.address, userAmount);
 
-      // Add bridged tokens to gateway
-      await gateway.connect(owner).addBridgedToken(await usdc.getAddress(), await usdcBridge.getAddress());
-      await gateway.connect(owner).addBridgedToken(await usdt.getAddress(), await usdtBridge.getAddress());
-      await gateway.connect(owner).addBridgedToken(await ctUsd.getAddress(), await ctUsdBridge.getAddress());
+      // Set bridges as approved minters (simulates JUSD governance approval)
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await jusd.setMinter(await usdtBridge.getAddress(), true);
+      await jusd.setMinter(await ctUsdBridge.getAddress(), true);
+
+      // Register bridged tokens on gateway (permissionless - anyone can call if bridge is minter)
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+      await gateway.registerBridgedToken(await usdtBridge.getAddress());
+      await gateway.registerBridgedToken(await ctUsdBridge.getAddress());
 
       return {
         owner,
@@ -2593,44 +2928,8 @@ describe("JuiceSwapGateway", function () {
       };
     }
 
-    describe("Admin Functions", function () {
-      it("Should add bridged token", async function () {
-        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
-
-        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
-
-        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
-        const newBridge = await MockBridgeFactory.deploy(
-          await newToken.getAddress(),
-          await jusd.getAddress(),
-          BRIDGE_LIMIT,
-          BRIDGE_WEEKS
-        );
-
-        await expect(
-          gateway.connect(owner).addBridgedToken(
-            await newToken.getAddress(),
-            await newBridge.getAddress()
-          )
-        ).to.emit(gateway, "BridgedTokenAdded")
-          .withArgs(await newToken.getAddress(), await newBridge.getAddress(), 6);
-
-        expect(await gateway.isBridgedToken(await newToken.getAddress())).to.be.true;
-      });
-
-      it("Should revert when adding duplicate bridged token", async function () {
-        const { gateway, owner, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
-
-        await expect(
-          gateway.connect(owner).addBridgedToken(
-            await usdc.getAddress(),
-            await usdcBridge.getAddress()
-          )
-        ).to.be.revertedWithCustomError(gateway, "BridgedTokenAlreadyExists");
-      });
-
-      it("Should revert when non-owner adds bridged token", async function () {
+    describe("Bridge Registration (Permissionless)", function () {
+      it("Should register bridged token when bridge is approved minter", async function () {
         const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
 
         const MockERC20Factory = await ethers.getContractFactory("MockERC20");
@@ -2644,55 +2943,70 @@ describe("JuiceSwapGateway", function () {
           BRIDGE_WEEKS
         );
 
-        await expect(
-          gateway.connect(user1).addBridgedToken(
-            await newToken.getAddress(),
-            await newBridge.getAddress()
-          )
-        ).to.be.revertedWithCustomError(gateway, "OwnableUnauthorizedAccount");
+        // Set bridge as approved minter (simulates JUSD governance approval)
+        await jusd.setMinter(await newBridge.getAddress(), true);
+
+        // Anyone can register (permissionless)
+        await expect(gateway.connect(user1).registerBridgedToken(await newBridge.getAddress()))
+          .to.emit(gateway, "BridgedTokenRegistered")
+          .withArgs(await newToken.getAddress(), await newBridge.getAddress(), user1.address, 6);
+
+        expect(await gateway.isBridgedToken(await newToken.getAddress())).to.be.true;
       });
 
-      it("Should remove bridged token", async function () {
-        const { gateway, owner, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+      it("Should revert when bridge is not approved minter", async function () {
+        const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
 
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
+
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
+
+        // Do NOT set bridge as minter - should fail
         await expect(
-          gateway.connect(owner).removeBridgedToken(await usdc.getAddress())
-        ).to.emit(gateway, "BridgedTokenRemoved")
-          .withArgs(await usdc.getAddress());
-
-        expect(await gateway.isBridgedToken(await usdc.getAddress())).to.be.false;
+          gateway.connect(user1).registerBridgedToken(await newBridge.getAddress())
+        ).to.be.revertedWithCustomError(gateway, "BridgeNotApprovedMinter");
       });
 
-      it("Should revoke both token and JUSD approvals when removing bridged token", async function () {
-        const { gateway, owner, usdc, usdt, usdcBridge, usdtBridge, jusd } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+      it("Should revert when bridge is stopped", async function () {
+        const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
 
-        const gatewayAddress = await gateway.getAddress();
-        const usdcBridgeAddress = await usdcBridge.getAddress();
-        const usdtBridgeAddress = await usdtBridge.getAddress();
+        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
 
-        // Verify both bridges have unlimited JUSD approval before removal
-        expect(await jusd.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(ethers.MaxUint256);
-        expect(await jusd.allowance(gatewayAddress, usdtBridgeAddress)).to.equal(ethers.MaxUint256);
+        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+        const newBridge = await MockBridgeFactory.deploy(
+          await newToken.getAddress(),
+          await jusd.getAddress(),
+          BRIDGE_LIMIT,
+          BRIDGE_WEEKS
+        );
 
-        // Remove USDC bridge
-        await gateway.connect(owner).removeBridgedToken(await usdc.getAddress());
+        // Set bridge as approved minter
+        await jusd.setMinter(await newBridge.getAddress(), true);
 
-        // Verify USDC bridge approvals are revoked
-        expect(await usdc.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(0);
-        expect(await jusd.allowance(gatewayAddress, usdcBridgeAddress)).to.equal(0);
+        // Stop the bridge
+        await newBridge.setStopped(true);
 
-        // Verify USDT bridge approvals remain unaffected
-        expect(await jusd.allowance(gatewayAddress, usdtBridgeAddress)).to.equal(ethers.MaxUint256);
+        // Should fail because bridge is stopped
+        await expect(
+          gateway.connect(user1).registerBridgedToken(await newBridge.getAddress())
+        ).to.be.revertedWithCustomError(gateway, "BridgeStopped");
       });
 
-      it("Should revert when removing non-existent bridged token", async function () {
-        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+      it("Should revert when registering duplicate bridged token", async function () {
+        const { gateway, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
-        const randomAddress = ethers.Wallet.createRandom().address;
-        await expect(
-          gateway.connect(owner).removeBridgedToken(randomAddress)
-        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+        await expect(gateway.registerBridgedToken(await usdcBridge.getAddress())).to.be.revertedWithCustomError(
+          gateway,
+          "BridgedTokenAlreadyExists"
+        );
       });
 
       it("Should return all bridged tokens", async function () {
@@ -2705,79 +3019,17 @@ describe("JuiceSwapGateway", function () {
         expect(tokens).to.include(await ctUsd.getAddress());
       });
 
-      it("Should revert with InvalidBridgeConfig for zero addresses", async function () {
-        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+      it("Should revert with InvalidBridgeConfig for zero address", async function () {
+        const { gateway } = await loadFixture(deployGatewayWithBalancesFixture);
 
-        await expect(
-          gateway.connect(owner).addBridgedToken(ethers.ZeroAddress, ethers.ZeroAddress)
-        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
-      });
-
-      it("Should revert with TooManyBridgedTokens when limit exceeded", async function () {
-        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
-
-        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
-
-        // Already have 3 tokens, add 7 more to reach limit of 10
-        for (let i = 0; i < 7; i++) {
-          const token = await MockERC20Factory.deploy(`Token${i}`, `TKN${i}`, 6);
-          const bridge = await MockBridgeFactory.deploy(
-            await token.getAddress(),
-            await jusd.getAddress(),
-            BRIDGE_LIMIT,
-            BRIDGE_WEEKS
-          );
-          await gateway.connect(owner).addBridgedToken(
-            await token.getAddress(),
-            await bridge.getAddress()
-          );
-        }
-
-        // 11th token should fail
-        const extraToken = await MockERC20Factory.deploy("Extra", "EXTRA", 6);
-        const extraBridge = await MockBridgeFactory.deploy(
-          await extraToken.getAddress(),
-          await jusd.getAddress(),
-          BRIDGE_LIMIT,
-          BRIDGE_WEEKS
+        await expect(gateway.registerBridgedToken(ethers.ZeroAddress)).to.be.revertedWithCustomError(
+          gateway,
+          "InvalidBridgeConfig"
         );
-
-        await expect(
-          gateway.connect(owner).addBridgedToken(
-            await extraToken.getAddress(),
-            await extraBridge.getAddress()
-          )
-        ).to.be.revertedWithCustomError(gateway, "TooManyBridgedTokens");
-      });
-
-      it("Should revert with InvalidBridgeConfig when bridge.usd() != token", async function () {
-        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
-
-        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
-
-        // Deploy a token and a bridge for a DIFFERENT token
-        const wrongToken = await MockERC20Factory.deploy("Wrong", "WRONG", 6);
-        const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
-        const bridge = await MockBridgeFactory.deploy(
-          await usdc.getAddress(),  // Bridge expects USDC
-          await jusd.getAddress(),
-          BRIDGE_LIMIT,
-          BRIDGE_WEEKS
-        );
-
-        // Try to add wrongToken with a bridge configured for USDC
-        await expect(
-          gateway.connect(owner).addBridgedToken(
-            await wrongToken.getAddress(),
-            await bridge.getAddress()
-          )
-        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
       });
 
       it("Should revert with InvalidBridgeConfig when bridge.JUSD() != gateway JUSD", async function () {
-        const { gateway, owner } = await loadFixture(deployGatewayWithBalancesFixture);
+        const { gateway, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
 
         const MockERC20Factory = await ethers.getContractFactory("MockERC20");
         const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
@@ -2787,24 +3039,23 @@ describe("JuiceSwapGateway", function () {
         const fakeJusd = await MockERC20Factory.deploy("Fake JUSD", "FJUSD", 18);
         const bridge = await MockBridgeFactory.deploy(
           await usdc.getAddress(),
-          await fakeJusd.getAddress(),  // Wrong JUSD
+          await fakeJusd.getAddress(), // Wrong JUSD
           BRIDGE_LIMIT,
           BRIDGE_WEEKS
         );
+        // Note: Even if we set minter, JUSD mismatch is checked first
+        await jusd.setMinter(await bridge.getAddress(), true);
 
-        await expect(
-          gateway.connect(owner).addBridgedToken(
-            await usdc.getAddress(),
-            await bridge.getAddress()
-          )
-        ).to.be.revertedWithCustomError(gateway, "InvalidBridgeConfig");
+        await expect(gateway.registerBridgedToken(await bridge.getAddress())).to.be.revertedWithCustomError(
+          gateway,
+          "InvalidBridgeConfig"
+        );
       });
     });
 
     describe("Swap with Bridged Tokens", function () {
       it("Should swap bridged token (USDC.e) to WcBTC", async function () {
-        const { gateway, user1, usdc, wcbtc, swapRouter } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+        const { gateway, user1, usdc, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
         const deadline = (await time.latest()) + DEADLINE_OFFSET;
         const swapAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
@@ -2830,8 +3081,9 @@ describe("JuiceSwapGateway", function () {
       });
 
       it("Should swap WcBTC to bridged token (USDT.e)", async function () {
-        const { gateway, user1, usdt, wcbtc, svJusd, swapRouter, usdtBridge } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+        const { gateway, user1, usdt, wcbtc, svJusd, swapRouter, usdtBridge } = await loadFixture(
+          deployGatewayWithBridgedTokensFixture
+        );
 
         const deadline = (await time.latest()) + DEADLINE_OFFSET;
         const swapAmount = ethers.parseEther("0.01"); // 0.01 WcBTC
@@ -2845,15 +3097,17 @@ describe("JuiceSwapGateway", function () {
 
         const usdtBefore = await usdt.balanceOf(user1.address);
 
-        await gateway.connect(user1).swapExactTokensForTokens(
-          await wcbtc.getAddress(),
-          await usdt.getAddress(),
-          0,
-          swapAmount,
-          0,
-          user1.address,
-          deadline
-        );
+        await gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await wcbtc.getAddress(),
+            await usdt.getAddress(),
+            0,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          );
 
         const usdtAfter = await usdt.balanceOf(user1.address);
         // 1000 JUSD (18 decimals) = 1000 USDT (6 decimals)
@@ -2861,8 +3115,7 @@ describe("JuiceSwapGateway", function () {
       });
 
       it("Should emit SwapExecuted event with bridged token addresses", async function () {
-        const { gateway, user1, usdc, wcbtc, swapRouter } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+        const { gateway, user1, usdc, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
         const deadline = (await time.latest()) + DEADLINE_OFFSET;
         const swapAmount = 1000n * 10n ** 6n;
@@ -2871,24 +3124,55 @@ describe("JuiceSwapGateway", function () {
         await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
 
         await expect(
-          gateway.connect(user1).swapExactTokensForTokens(
-            await usdc.getAddress(),
-            await wcbtc.getAddress(),
-            0,
-            swapAmount,
-            0,
-            user1.address,
-            deadline
-          )
-        ).to.emit(gateway, "SwapExecuted")
+          gateway
+            .connect(user1)
+            .swapExactTokensForTokens(
+              await usdc.getAddress(),
+              await wcbtc.getAddress(),
+              0,
+              swapAmount,
+              0,
+              user1.address,
+              deadline
+            )
+        )
+          .to.emit(gateway, "SwapExecuted")
           .withArgs(user1.address, await usdc.getAddress(), await wcbtc.getAddress(), anyValue, anyValue);
+      });
+
+      it("Should revert when swapping from stopped bridge", async function () {
+        const { gateway, user1, usdc, wcbtc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const swapAmount = 1000n * 10n ** 6n;
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), swapAmount);
+
+        // Stop the bridge
+        await usdcBridge.setStopped(true);
+
+        // Swap should revert with bridge's Stopped error
+        await expect(
+          gateway
+            .connect(user1)
+            .swapExactTokensForTokens(
+              await usdc.getAddress(),
+              await wcbtc.getAddress(),
+              0,
+              swapAmount,
+              0,
+              user1.address,
+              deadline
+            )
+        ).to.be.revertedWithCustomError(usdcBridge, "Stopped");
       });
     });
 
     describe("Add Liquidity with Bridged Tokens", function () {
       it("Should add liquidity with bridged token (USDC.e) + WcBTC", async function () {
-        const { gateway, user1, usdc, wcbtc, svJusd, positionManager } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+        const { gateway, user1, usdc, wcbtc, svJusd, positionManager } = await loadFixture(
+          deployGatewayWithBridgedTokensFixture
+        );
 
         const deadline = (await time.latest()) + DEADLINE_OFFSET;
         const usdcAmount = 1000n * 10n ** 6n; // 1000 USDC (6 decimals)
@@ -2900,9 +3184,7 @@ describe("JuiceSwapGateway", function () {
 
         const svJusdAddr = await svJusd.getAddress();
         const wcbtcAddr = await wcbtc.getAddress();
-        const [amount0, amount1] = svJusdAddr < wcbtcAddr
-          ? [svJusdShares, wcbtcAmount]
-          : [wcbtcAmount, svJusdShares];
+        const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
 
         await positionManager.setMintResult(1, 100, amount0, amount1);
 
@@ -2913,6 +3195,8 @@ describe("JuiceSwapGateway", function () {
           await usdc.getAddress(),
           await wcbtc.getAddress(),
           0, // default fee
+          0, // tickLower (full range)
+          0, // tickUpper (full range)
           usdcAmount,
           wcbtcAmount,
           0,
@@ -2927,8 +3211,7 @@ describe("JuiceSwapGateway", function () {
       });
 
       it("Should revert with InvalidTokenPair for bridged token + JUSD", async function () {
-        const { gateway, user1, usdc, jusd } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+        const { gateway, user1, usdc, jusd } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
         const deadline = (await time.latest()) + DEADLINE_OFFSET;
         const amount = 1000n * 10n ** 6n;
@@ -2941,6 +3224,8 @@ describe("JuiceSwapGateway", function () {
             await usdc.getAddress(),
             await jusd.getAddress(),
             0,
+            0, // tickLower (full range)
+            0, // tickUpper (full range)
             amount,
             ethers.parseEther("1000"),
             0,
@@ -2952,8 +3237,7 @@ describe("JuiceSwapGateway", function () {
       });
 
       it("Should revert with InvalidTokenPair for two bridged tokens", async function () {
-        const { gateway, user1, usdc, usdt } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+        const { gateway, user1, usdc, usdt } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
         const deadline = (await time.latest()) + DEADLINE_OFFSET;
         const amount = 1000n * 10n ** 6n;
@@ -2966,6 +3250,8 @@ describe("JuiceSwapGateway", function () {
             await usdc.getAddress(),
             await usdt.getAddress(),
             0,
+            0, // tickLower (full range)
+            0, // tickUpper (full range)
             amount,
             amount,
             0,
@@ -2974,6 +3260,116 @@ describe("JuiceSwapGateway", function () {
             deadline
           )
         ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+      });
+
+      it("Should return excess bridged token when position manager uses less", async function () {
+        const { gateway, user1, usdc, wcbtc, svJusd, positionManager, usdcBridge } = await loadFixture(
+          deployGatewayWithBridgedTokensFixture
+        );
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const usdcAmount = 2000n * 10n ** 6n; // 2000 USDC (6 decimals)
+        const wcbtcAmount = ethers.parseEther("0.02");
+
+        // Calculate expected svJUSD from full USDC amount
+        const jusdEquivalent = ethers.parseEther("2000"); // 2000 USDC = 2000 JUSD
+        const fullSvJusdShares = await svJusd.convertToShares(jusdEquivalent);
+
+        // Mock position manager to only use HALF the svJUSD (simulating excess)
+        const halfSvJusdShares = fullSvJusdShares / 2n;
+        const halfWcbtc = wcbtcAmount / 2n;
+
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const [amount0, amount1] =
+          svJusdAddr < wcbtcAddr ? [halfSvJusdShares, halfWcbtc] : [halfWcbtc, halfSvJusdShares];
+        await positionManager.setMintResult(1, 100, amount0, amount1);
+
+        // Set minted amount for bridge burn operation (excess will be burned)
+        await usdcBridge.setMinted(jusdEquivalent);
+
+        await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+        const usdcBefore = await usdc.balanceOf(user1.address);
+
+        await gateway.connect(user1).addLiquidity(
+          await usdc.getAddress(),
+          await wcbtc.getAddress(),
+          0,
+          0, // tickLower (full range)
+          0, // tickUpper (full range)
+          usdcAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+        const usdcAfter = await usdc.balanceOf(user1.address);
+
+        // User should receive excess USDC back (half of input = 1000 USDC)
+        // Initial: usdcBefore, spent 2000, got back ~1000 = usdcBefore - 1000
+        const usdcSpent = usdcBefore - usdcAfter;
+        expect(usdcSpent).to.be.lt(usdcAmount); // Should have received some back
+        expect(usdcSpent).to.be.closeTo(1000n * 10n ** 6n, 100n * 10n ** 6n); // ~1000 USDC used
+      });
+
+      it("Should return excess bridged token (USDT) when increasing liquidity", async function () {
+        const { gateway, user1, usdt, wcbtc, svJusd, positionManager, usdtBridge } = await loadFixture(
+          deployGatewayWithBridgedTokensFixture
+        );
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const tokenId = 1;
+        const usdtAmount = 2000n * 10n ** 6n; // 2000 USDT
+        const wcbtcAmount = ethers.parseEther("0.02");
+
+        // Setup position with correct token ordering
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+        await positionManager.setPositionData(tokenId, token0, token1, 100);
+        await positionManager.mintNFT(user1.address, tokenId);
+        await positionManager.connect(user1).approve(await gateway.getAddress(), tokenId);
+
+        // Mock increase to use only half
+        const jusdEquivalent = ethers.parseEther("2000");
+        const fullSvJusdShares = await svJusd.convertToShares(jusdEquivalent);
+        const halfSvJusdShares = fullSvJusdShares / 2n;
+        const halfWcbtc = wcbtcAmount / 2n;
+
+        const [inc0, inc1] = svJusdAddr < wcbtcAddr ? [halfSvJusdShares, halfWcbtc] : [halfWcbtc, halfSvJusdShares];
+        await positionManager.setIncreaseResult(50, inc0, inc1);
+
+        // Set minted for bridge burn
+        await usdtBridge.setMinted(jusdEquivalent);
+
+        await usdt.connect(user1).approve(await gateway.getAddress(), usdtAmount);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+        const usdtBefore = await usdt.balanceOf(user1.address);
+
+        await gateway
+          .connect(user1)
+          .increaseLiquidity(
+            tokenId,
+            await usdt.getAddress(),
+            await wcbtc.getAddress(),
+            usdtAmount,
+            wcbtcAmount,
+            0,
+            0,
+            deadline
+          );
+
+        const usdtAfter = await usdt.balanceOf(user1.address);
+
+        // User should receive excess USDT back
+        const usdtSpent = usdtBefore - usdtAfter;
+        expect(usdtSpent).to.be.lt(usdtAmount);
+        expect(usdtSpent).to.be.closeTo(1000n * 10n ** 6n, 100n * 10n ** 6n);
       });
     });
 
@@ -3014,9 +3410,10 @@ describe("JuiceSwapGateway", function () {
       it("Should revert bridgedToSvJusd for non-bridged token", async function () {
         const { gateway, wcbtc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
-        await expect(
-          gateway.bridgedToSvJusd(await wcbtc.getAddress(), 1000)
-        ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+        await expect(gateway.bridgedToSvJusd(await wcbtc.getAddress(), 1000)).to.be.revertedWithCustomError(
+          gateway,
+          "BridgedTokenNotFound"
+        );
       });
 
       it("Should revert svJusdToBridged for non-bridged token", async function () {
@@ -3078,8 +3475,9 @@ describe("JuiceSwapGateway", function () {
 
     describe("Multiple Bridged Tokens", function () {
       it("Should support swapping between different bridged tokens via pool", async function () {
-        const { gateway, user1, usdc, usdt, svJusd, swapRouter, usdtBridge } =
-          await loadFixture(deployGatewayWithBridgedTokensFixture);
+        const { gateway, user1, usdc, usdt, svJusd, swapRouter, usdtBridge } = await loadFixture(
+          deployGatewayWithBridgedTokensFixture
+        );
 
         const deadline = (await time.latest()) + DEADLINE_OFFSET;
         const swapAmount = 1000n * 10n ** 6n; // 1000 USDC
@@ -3094,15 +3492,17 @@ describe("JuiceSwapGateway", function () {
 
         const usdtBefore = await usdt.balanceOf(user1.address);
 
-        await gateway.connect(user1).swapExactTokensForTokens(
-          await usdc.getAddress(),
-          await usdt.getAddress(),
-          0,
-          swapAmount,
-          0,
-          user1.address,
-          deadline
-        );
+        await gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await usdc.getAddress(),
+            await usdt.getAddress(),
+            0,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          );
 
         const usdtAfter = await usdt.balanceOf(user1.address);
         expect(usdtAfter - usdtBefore).to.equal(1000n * 10n ** 6n);
@@ -3153,22 +3553,6 @@ describe("JuiceSwapGateway", function () {
         expect(status.burnBlockReason).to.equal("Token not supported");
       });
 
-      it("Should return stopped status when bridge is stopped", async function () {
-        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
-
-        // Stop the bridge
-        await usdcBridge.setStopped(true);
-
-        const status = await gateway.getBridgeStatus(await usdc.getAddress());
-
-        expect(status.canMint).to.be.false;
-        expect(status.canBurn).to.be.true; // Burn should still work
-        expect(status.mintCapacity).to.equal(0);
-        expect(status.burnCapacity).to.equal(bridgeAmount); // Bridge still has liquidity
-        expect(status.mintBlockReason).to.equal("Bridge stopped");
-        expect(status.burnBlockReason).to.equal("");
-      });
-
       it("Should return expired status when bridge horizon is passed", async function () {
         const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
@@ -3217,8 +3601,9 @@ describe("JuiceSwapGateway", function () {
           BRIDGE_WEEKS
         );
 
-        // Add to gateway but don't fund the bridge
-        await gateway.connect(owner).addBridgedToken(await newToken.getAddress(), await newBridge.getAddress());
+        // Set bridge as approved minter and register (permissionless)
+        await jusd.setMinter(await newBridge.getAddress(), true);
+        await gateway.registerBridgedToken(await newBridge.getAddress());
 
         const status = await gateway.getBridgeStatus(await newToken.getAddress());
 
@@ -3234,7 +3619,7 @@ describe("JuiceSwapGateway", function () {
         const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
         // Set minted to 40% of limit
-        const mintedAmount = BRIDGE_LIMIT * 40n / 100n;
+        const mintedAmount = (BRIDGE_LIMIT * 40n) / 100n;
         await usdcBridge.setMinted(mintedAmount);
 
         const status = await gateway.getBridgeStatus(await usdc.getAddress());
@@ -3247,37 +3632,4229 @@ describe("JuiceSwapGateway", function () {
         expect(status.burnBlockReason).to.equal("");
       });
 
-      it("Should handle combined failure: stopped bridge with no liquidity", async function () {
-        const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
-
-        // Deploy a new bridged token with empty bridge
-        const MockERC20Factory = await ethers.getContractFactory("MockERC20");
-        const newToken = await MockERC20Factory.deploy("New Token", "NEW", 6);
-
-        const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
-        const newBridge = await MockBridgeFactory.deploy(
-          await newToken.getAddress(),
-          await jusd.getAddress(),
-          BRIDGE_LIMIT,
-          BRIDGE_WEEKS
-        );
-
-        // Add to gateway but don't fund the bridge
-        await gateway.connect(owner).addBridgedToken(await newToken.getAddress(), await newBridge.getAddress());
+      it("Should return stopped status when bridge is stopped", async function () {
+        const { gateway, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
 
         // Stop the bridge
-        await newBridge.setStopped(true);
+        await usdcBridge.setStopped(true);
 
-        const status = await gateway.getBridgeStatus(await newToken.getAddress());
+        const status = await gateway.getBridgeStatus(await usdc.getAddress());
 
-        // Both mint and burn should be blocked for different reasons
         expect(status.canMint).to.be.false;
-        expect(status.canBurn).to.be.false;
+        expect(status.canBurn).to.be.true; // Burn should still work (bridge allows burn when stopped)
         expect(status.mintCapacity).to.equal(0);
-        expect(status.burnCapacity).to.equal(0);
+        expect(status.burnCapacity).to.equal(bridgeAmount);
         expect(status.mintBlockReason).to.equal("Bridge stopped");
-        expect(status.burnBlockReason).to.equal("Insufficient bridge liquidity");
+        expect(status.burnBlockReason).to.equal("");
       });
+    });
+
+    describe("Direct USD Conversion Optimization", function () {
+      /**
+       * These tests verify the gas-optimized direct USD conversion path.
+       * Instead of: Input -> svJUSD deposit -> svJUSD redeem -> Output
+       * We do:      Input -> JUSD -> Output (skipping vault roundtrip)
+       */
+
+      it("Should directly convert JUSD to bridged token (skip svJUSD)", async function () {
+        const { gateway, user1, jusd, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const jusdAmount = ethers.parseEther("100");
+        const deadline = (await time.latest()) + 3600;
+
+        // Mint JUSD to user
+        await jusd.mint(user1.address, jusdAmount);
+        await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+
+        // Fund bridge with USDC for burn operation
+        const usdcAmount = 100_000_000n; // 100 USDC (6 decimals)
+        await usdc.mint(await usdcBridge.getAddress(), usdcAmount);
+
+        // Set minted amount so burn can decrease it (minted -= amount)
+        await usdcBridge.setMinted(jusdAmount);
+
+        const usdcBefore = await usdc.balanceOf(user1.address);
+
+        // Swap JUSD -> USDC.e (should use direct path, not svJUSD roundtrip)
+        await gateway.connect(user1).swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await usdc.getAddress(),
+          0, // fee (not used for direct conversion)
+          jusdAmount,
+          0, // minAmountOut
+          user1.address,
+          deadline
+        );
+
+        const usdcAfter = await usdc.balanceOf(user1.address);
+        const expectedUsdc = jusdAmount / 10n ** 12n; // 18 decimals -> 6 decimals
+
+        expect(usdcAfter - usdcBefore).to.equal(expectedUsdc);
+      });
+
+      it("Should directly convert bridged token to JUSD (skip svJUSD)", async function () {
+        const { gateway, user1, jusd, usdc } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const usdcAmount = 100_000_000n; // 100 USDC (6 decimals)
+        const deadline = (await time.latest()) + 3600;
+
+        // Mint USDC to user
+        await usdc.mint(user1.address, usdcAmount);
+        await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+
+        const jusdBefore = await jusd.balanceOf(user1.address);
+
+        // Swap USDC.e -> JUSD (should use direct path)
+        await gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await usdc.getAddress(),
+            await jusd.getAddress(),
+            0,
+            usdcAmount,
+            0,
+            user1.address,
+            deadline
+          );
+
+        const jusdAfter = await jusd.balanceOf(user1.address);
+        const expectedJusd = usdcAmount * 10n ** 12n; // 6 decimals -> 18 decimals
+
+        expect(jusdAfter - jusdBefore).to.equal(expectedJusd);
+      });
+
+      it("Should directly convert between bridged tokens (skip svJUSD)", async function () {
+        const { gateway, user1, usdc, usdt, usdtBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const usdcAmount = 100_000_000n; // 100 USDC (6 decimals)
+        const deadline = (await time.latest()) + 3600;
+
+        // Mint USDC to user
+        await usdc.mint(user1.address, usdcAmount);
+        await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+
+        // Fund USDT bridge for burn operation
+        await usdt.mint(await usdtBridge.getAddress(), usdcAmount);
+
+        // Set minted for USDT bridge (USDC converts to JUSD, then JUSD burns on USDT bridge)
+        const jusdAmount = usdcAmount * 10n ** 12n; // 6 decimals -> 18 decimals
+        await usdtBridge.setMinted(jusdAmount);
+
+        const usdtBefore = await usdt.balanceOf(user1.address);
+
+        // Swap USDC.e -> USDT.e (should use direct path)
+        await gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await usdc.getAddress(),
+            await usdt.getAddress(),
+            0,
+            usdcAmount,
+            0,
+            user1.address,
+            deadline
+          );
+
+        const usdtAfter = await usdt.balanceOf(user1.address);
+
+        // Both have 6 decimals, so amounts should match (minus any bridge fees)
+        expect(usdtAfter - usdtBefore).to.equal(usdcAmount);
+      });
+
+      it("Should directly convert JUSD to JUICE (skip svJUSD)", async function () {
+        const { gateway, user1, jusd, juice } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const jusdAmount = ethers.parseEther("100");
+        const deadline = (await time.latest()) + 3600;
+
+        // Mint JUSD to user
+        await jusd.mint(user1.address, jusdAmount);
+        await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+
+        const juiceBefore = await juice.balanceOf(user1.address);
+
+        // Swap JUSD -> JUICE (should use direct path via Equity.invest)
+        await gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await jusd.getAddress(),
+            await juice.getAddress(),
+            0,
+            jusdAmount,
+            0,
+            user1.address,
+            deadline
+          );
+
+        const juiceAfter = await juice.balanceOf(user1.address);
+
+        // MockEquity uses PRICE = 100e18, so 100 JUSD = 1 JUICE
+        const expectedJuice = jusdAmount / 100n;
+        expect(juiceAfter - juiceBefore).to.equal(expectedJuice);
+      });
+
+      it("Should directly convert bridged token to JUICE (skip svJUSD)", async function () {
+        const { gateway, user1, usdc, juice } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const usdcAmount = 100_000_000n; // 100 USDC (6 decimals)
+        const deadline = (await time.latest()) + 3600;
+
+        // Mint USDC to user
+        await usdc.mint(user1.address, usdcAmount);
+        await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+
+        const juiceBefore = await juice.balanceOf(user1.address);
+
+        // Swap USDC.e -> JUICE (should use direct path)
+        await gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await usdc.getAddress(),
+            await juice.getAddress(),
+            0,
+            usdcAmount,
+            0,
+            user1.address,
+            deadline
+          );
+
+        const juiceAfter = await juice.balanceOf(user1.address);
+        const jusdEquivalent = usdcAmount * 10n ** 12n; // 6 decimals -> 18 decimals
+        // MockEquity uses PRICE = 100e18, so 100 JUSD = 1 JUICE
+        const expectedJuice = jusdEquivalent / 100n;
+
+        expect(juiceAfter - juiceBefore).to.equal(expectedJuice);
+      });
+
+      it("Should emit SwapExecuted event for direct conversion", async function () {
+        const { gateway, user1, jusd, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const jusdAmount = ethers.parseEther("100");
+        const deadline = (await time.latest()) + 3600;
+
+        await jusd.mint(user1.address, jusdAmount);
+        await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+        await usdc.mint(await usdcBridge.getAddress(), 100_000_000n);
+        await usdcBridge.setMinted(jusdAmount);
+
+        await expect(
+          gateway
+            .connect(user1)
+            .swapExactTokensForTokens(
+              await jusd.getAddress(),
+              await usdc.getAddress(),
+              0,
+              jusdAmount,
+              0,
+              user1.address,
+              deadline
+            )
+        )
+          .to.emit(gateway, "SwapExecuted")
+          .withArgs(user1.address, await jusd.getAddress(), await usdc.getAddress(), jusdAmount, anyValue);
+      });
+
+      it("Should revert if minAmountOut not met in direct conversion", async function () {
+        const { gateway, user1, jusd, usdc, usdcBridge } = await loadFixture(deployGatewayWithBridgedTokensFixture);
+
+        const jusdAmount = ethers.parseEther("100");
+        const deadline = (await time.latest()) + 3600;
+
+        await jusd.mint(user1.address, jusdAmount);
+        await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+        await usdc.mint(await usdcBridge.getAddress(), 100_000_000n);
+        await usdcBridge.setMinted(jusdAmount);
+
+        // Expect 200 USDC but only 100 USDC will be received
+        const unreasonableMinOutput = 200_000_000n; // 200 USDC
+
+        await expect(
+          gateway
+            .connect(user1)
+            .swapExactTokensForTokens(
+              await jusd.getAddress(),
+              await usdc.getAddress(),
+              0,
+              jusdAmount,
+              unreasonableMinOutput,
+              user1.address,
+              deadline
+            )
+        ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+      });
+
+      it("Should still use pool swap for cBTC to JUSD (not direct)", async function () {
+        const { gateway, user1, wcbtc, jusd, svJusd, swapRouter } = await loadFixture(
+          deployGatewayWithBridgedTokensFixture
+        );
+
+        const cbtcAmount = ethers.parseEther("1");
+        const deadline = (await time.latest()) + 3600;
+
+        // Fund user with native cBTC
+        await user1.sendTransaction({
+          to: await wcbtc.getAddress(),
+          value: cbtcAmount,
+        });
+
+        // Setup mock swap router to return svJUSD
+        const expectedSvJusd = ethers.parseEther("50000");
+        // Use explicit function signature to avoid ambiguity with ERC4626.mint(uint256,address)
+        await svJusd["mint(address,uint256)"](await swapRouter.getAddress(), expectedSvJusd);
+        await swapRouter.setSwapOutput(expectedSvJusd);
+
+        // This should NOT use direct conversion (cBTC is not a USD token)
+        // It should go through the normal pool swap path
+        await gateway.connect(user1).swapExactTokensForTokens(
+          ethers.ZeroAddress, // Native cBTC
+          await jusd.getAddress(),
+          3000,
+          cbtcAmount,
+          0,
+          user1.address,
+          deadline,
+          { value: cbtcAmount }
+        );
+
+        // Verify swap router was called (not direct path)
+        // The exact assertion depends on mock implementation
+      });
+    });
+  });
+
+  // ==================== Pool Creation Tests ====================
+
+  describe("Pool Creation", function () {
+    describe("getPool", function () {
+      it("Should return pool address when pool exists", async function () {
+        const { gateway, jusd, wcbtc, positionManager, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const mockPoolAddr = "0x0000000000000000000000000000000000001234";
+
+        // Get the factory from the position manager (Gateway uses POSITION_MANAGER.factory())
+        const factoryAddr = await positionManager.factory();
+        const MockFactoryFactory = await ethers.getContractFactory("MockFactory");
+        const factory = MockFactoryFactory.attach(factoryAddr);
+
+        // Set pool in mock factory
+        await factory.setPool(svJusdAddr, wcbtcAddr, 3000, mockPoolAddr);
+
+        const [pool, exists] = await gateway.getPool(await jusd.getAddress(), await wcbtc.getAddress(), 3000);
+
+        expect(exists).to.be.true;
+        expect(pool).to.equal(mockPoolAddr);
+      });
+
+      it("Should return (address(0), false) when pool does not exist", async function () {
+        const { gateway, jusd, wcbtc } = await loadFixture(deployGatewayFixture);
+
+        const [pool, exists] = await gateway.getPool(await jusd.getAddress(), await wcbtc.getAddress(), 3000);
+
+        expect(exists).to.be.false;
+        expect(pool).to.equal(ethers.ZeroAddress);
+      });
+
+      it("Should use default fee when fee is 0", async function () {
+        const { gateway, jusd, wcbtc, positionManager, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const mockPoolAddr = "0x0000000000000000000000000000000000005678";
+
+        // Get the factory from the position manager
+        const factoryAddr = await positionManager.factory();
+        const MockFactoryFactory = await ethers.getContractFactory("MockFactory");
+        const factory = MockFactoryFactory.attach(factoryAddr);
+
+        // Set pool with default fee (3000)
+        await factory.setPool(svJusdAddr, wcbtcAddr, 3000, mockPoolAddr);
+
+        // Query with fee=0 should use default (3000)
+        const [pool, exists] = await gateway.getPool(await jusd.getAddress(), await wcbtc.getAddress(), 0);
+
+        expect(exists).to.be.true;
+        expect(pool).to.equal(mockPoolAddr);
+      });
+
+      it("Should correctly map JUSD to svJUSD for pool lookup", async function () {
+        const { gateway, jusd, wcbtc, positionManager, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const mockPoolAddr = "0x0000000000000000000000000000000000009abc";
+
+        // Get the factory from the position manager
+        const factoryAddr = await positionManager.factory();
+        const MockFactoryFactory = await ethers.getContractFactory("MockFactory");
+        const factory = MockFactoryFactory.attach(factoryAddr);
+
+        // Set pool with svJUSD (not JUSD)
+        await factory.setPool(svJusdAddr, wcbtcAddr, 3000, mockPoolAddr);
+
+        // Query with JUSD should find the svJUSD pool
+        const [pool, exists] = await gateway.getPool(await jusd.getAddress(), await wcbtc.getAddress(), 3000);
+
+        expect(exists).to.be.true;
+        expect(pool.toLowerCase()).to.equal(mockPoolAddr.toLowerCase());
+      });
+    });
+
+    describe("createPool", function () {
+      it("Should create a new pool with JUSD/WcBTC", async function () {
+        const { gateway, user1, jusd, wcbtc, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        // Initial sqrt price: 1:1 ratio
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // sqrt(1) * 2^96
+
+        const tx = await gateway
+          .connect(user1)
+          .createPool(await jusd.getAddress(), await wcbtc.getAddress(), 3000, sqrtPriceX96);
+
+        await expect(tx).to.emit(gateway, "PoolCreated");
+      });
+
+      it("Should use default fee when fee is 0", async function () {
+        const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+        const tx = await gateway
+          .connect(user1)
+          .createPool(await jusd.getAddress(), await wcbtc.getAddress(), 0, sqrtPriceX96);
+
+        // Should emit event with fee=3000 (default)
+        await expect(tx).to.emit(gateway, "PoolCreated");
+      });
+
+      it("Should revert for JUICE/JUSD pair", async function () {
+        const { gateway, user1, juice, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+        await expect(
+          gateway.connect(user1).createPool(await juice.getAddress(), await jusd.getAddress(), 3000, sqrtPriceX96)
+        ).to.be.revertedWithCustomError(gateway, "JuiceCannotPairWithUsd");
+      });
+
+      it("Should revert for same token pair", async function () {
+        const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+        await expect(
+          gateway.connect(user1).createPool(await jusd.getAddress(), await jusd.getAddress(), 3000, sqrtPriceX96)
+        ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+      });
+
+      it("Should revert for invalid fee tier", async function () {
+        const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+        await expect(
+          gateway.connect(user1).createPool(await jusd.getAddress(), await wcbtc.getAddress(), 1_000_000, sqrtPriceX96)
+        ).to.be.revertedWithCustomError(gateway, "InvalidFee");
+      });
+
+      it("Should revert for zero sqrt price", async function () {
+        const { gateway, user1, juice, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        await expect(
+          gateway.connect(user1).createPool(await juice.getAddress(), await wcbtc.getAddress(), 3000, 0)
+        ).to.be.revertedWithCustomError(gateway, "InvalidPrice");
+      });
+    });
+
+    describe("createPoolAndAddLiquidity", function () {
+      it("Should create pool and add liquidity in one transaction", async function () {
+        const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+          deployGatewayWithBalancesFixture
+        );
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // 1:1
+        const jusdAmount = ethers.parseEther("100");
+        const wcbtcAmount = ethers.parseEther("100");
+
+        // Calculate svJUSD shares
+        const svJusdShares = await svJusd.convertToShares(jusdAmount);
+
+        // Setup mock
+        const svJusdAddr = await svJusd.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+        await positionManager.setMintResult(1, 100, amount0, amount1);
+
+        // Approve tokens
+        await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+        const tx = await gateway.connect(user1).createPoolAndAddLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          sqrtPriceX96,
+          0, // full range
+          0,
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+        // Should emit both events
+        await expect(tx).to.emit(gateway, "PoolCreated");
+        await expect(tx).to.emit(gateway, "LiquidityAdded");
+      });
+
+      it("Should revert if deadline expired", async function () {
+        const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const expiredDeadline = (await time.latest()) - 1;
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+        const amount = ethers.parseEther("100");
+
+        await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+        await expect(
+          gateway
+            .connect(user1)
+            .createPoolAndAddLiquidity(
+              await jusd.getAddress(),
+              await wcbtc.getAddress(),
+              3000,
+              sqrtPriceX96,
+              0,
+              0,
+              amount,
+              amount,
+              0,
+              0,
+              user1.address,
+              expiredDeadline
+            )
+        ).to.be.revertedWithCustomError(gateway, "DeadlineExpired");
+      });
+
+      it("Should revert for JUICE/JUSD pair", async function () {
+        const { gateway, user1, juice, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+        const amount = ethers.parseEther("100");
+
+        await expect(
+          gateway
+            .connect(user1)
+            .createPoolAndAddLiquidity(
+              await juice.getAddress(),
+              await jusd.getAddress(),
+              3000,
+              sqrtPriceX96,
+              0,
+              0,
+              amount,
+              amount,
+              0,
+              0,
+              user1.address,
+              deadline
+            )
+        ).to.be.revertedWithCustomError(gateway, "JuiceCannotPairWithUsd");
+      });
+
+      it("Should work with JUICE/WcBTC pair", async function () {
+        const { gateway, user1, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        const deadline = (await time.latest()) + DEADLINE_OFFSET;
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+        const juiceAmount = ethers.parseEther("100");
+        const wcbtcAmount = ethers.parseEther("100");
+
+        // Setup mock
+        const juiceAddr = await juice.getAddress();
+        const wcbtcAddr = await wcbtc.getAddress();
+        const [amount0, amount1] = juiceAddr < wcbtcAddr ? [juiceAmount, wcbtcAmount] : [wcbtcAmount, juiceAmount];
+
+        await positionManager.setMintResult(1, 100, amount0, amount1);
+
+        // Approve tokens
+        await juice.connect(user1).approve(await gateway.getAddress(), juiceAmount);
+        await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+        const tx = await gateway
+          .connect(user1)
+          .createPoolAndAddLiquidity(
+            await juice.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            sqrtPriceX96,
+            0,
+            0,
+            juiceAmount,
+            wcbtcAmount,
+            0,
+            0,
+            user1.address,
+            deadline
+          );
+
+        await expect(tx).to.emit(gateway, "PoolCreated");
+        await expect(tx).to.emit(gateway, "LiquidityAdded");
+      });
+    });
+
+    describe("Price Conversion", function () {
+      it("Should not convert price when neither token is JUSD-based", async function () {
+        const { gateway, user1, juice, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        // JUICE/WcBTC - no conversion needed
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+        // This should work without any price conversion issues
+        const tx = await gateway
+          .connect(user1)
+          .createPool(await juice.getAddress(), await wcbtc.getAddress(), 3000, sqrtPriceX96);
+
+        await expect(tx).to.emit(gateway, "PoolCreated");
+      });
+
+      it("Should convert price when JUSD is involved", async function () {
+        const { gateway, user1, jusd, wcbtc, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+        // Simulate interest accrual (1 svJUSD = 1.1 JUSD)
+        await svJusd.accrueInterest(ethers.parseEther("10"));
+
+        const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // 1:1 in JUSD terms
+
+        // This should create pool with adjusted price for svJUSD
+        const tx = await gateway
+          .connect(user1)
+          .createPool(await jusd.getAddress(), await wcbtc.getAddress(), 3000, sqrtPriceX96);
+
+        await expect(tx).to.emit(gateway, "PoolCreated");
+      });
+    });
+  });
+
+  // ==================== Extended Test Coverage ====================
+
+  describe("Reentrancy Protection", function () {
+    it("Should prevent reentrancy on swapExactTokensForTokens via malicious ERC20 transferFrom", async function () {
+      const { gateway, user1, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy malicious ERC20
+      const MaliciousERC20Factory = await ethers.getContractFactory("MaliciousERC20");
+      const maliciousToken = await MaliciousERC20Factory.deploy();
+      await maliciousToken.waitForDeployment();
+
+      const maliciousAddr = await maliciousToken.getAddress();
+      const gatewayAddr = await gateway.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Setup malicious token
+      await maliciousToken.mint(user1.address, ethers.parseEther("1000"));
+      await maliciousToken.connect(user1).approve(gatewayAddr, ethers.MaxUint256);
+      await maliciousToken.setTarget(gatewayAddr, wcbtcAddr);
+      await maliciousToken.enableAttackOnTransferFrom(true);
+
+      // Setup swap router to accept the malicious token
+      await swapRouter.setSwapOutput(ethers.parseEther("0.5"));
+
+      const deadline = (await time.latest()) + 3600;
+
+      // The malicious token will attempt reentrancy during transferFrom
+      // The ReentrancyGuard should prevent the nested call
+      // Original transaction should still complete
+      await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(maliciousAddr, wcbtcAddr, 3000, ethers.parseEther("10"), 0, user1.address, deadline);
+
+      // Attack was attempted but caught by ReentrancyGuard
+      // Note: attackCount may be > 1 if multiple transfers occur during the swap
+      expect(await maliciousToken.attackCount()).to.be.gte(1);
+    });
+
+    it("Should prevent reentrancy on removeLiquidity via native token receive callback", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      // Deploy malicious receiver
+      const MaliciousReceiverFactory = await ethers.getContractFactory("MaliciousReceiver");
+      const maliciousReceiver = await MaliciousReceiverFactory.deploy();
+      await maliciousReceiver.waitForDeployment();
+
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const jusdAddr = await jusd.getAddress();
+
+      // Setup position
+      const tokenId = 1;
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      await positionManager.setPositionData(tokenId, token0, token1, 100);
+      await positionManager.setDecreaseResult(ethers.parseEther("100"), ethers.parseEther("1"));
+
+      // Fund position manager with svJUSD
+      await jusd.mint(owner.address, ethers.parseEther("200"));
+      await jusd.connect(owner).approve(await svJusd.getAddress(), ethers.parseEther("200"));
+      await svJusd.connect(owner).deposit(ethers.parseEther("100"), posManagerAddr);
+      await wcbtc.deposit({ value: ethers.parseEther("100") });
+      await wcbtc.transfer(posManagerAddr, ethers.parseEther("100"));
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      // Setup malicious receiver to attempt reentrancy
+      await maliciousReceiver.setAttackRemoveLiquidity(
+        gatewayAddr,
+        tokenId,
+        ethers.ZeroAddress, // Native cBTC
+        jusdAddr
+      );
+      await maliciousReceiver.enableAttack(true);
+
+      const deadline = (await time.latest()) + 3600;
+
+      // This should complete despite reentrancy attempt
+      // The malicious receiver will try to call removeLiquidity again when it receives native cBTC
+      await gateway.connect(user1).removeLiquidity(
+        tokenId,
+        0,
+        ethers.ZeroAddress, // Native cBTC output
+        jusdAddr,
+        0,
+        0,
+        await maliciousReceiver.getAddress(),
+        deadline
+      );
+
+      // Attack was attempted
+      expect(await maliciousReceiver.attackCount()).to.equal(1);
+    });
+  });
+
+  describe("receive() Function Extended Tests", function () {
+    it("Should reject native tokens from arbitrary contracts", async function () {
+      const { gateway, user1 } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy a contract that can receive and forward native tokens
+      const SimpleForwarderFactory = await ethers.getContractFactory("MaliciousReceiver");
+      const forwarder = await SimpleForwarderFactory.deploy();
+      await forwarder.waitForDeployment();
+
+      // Fund the forwarder contract
+      await user1.sendTransaction({
+        to: await forwarder.getAddress(),
+        value: ethers.parseEther("1"),
+      });
+
+      // The gateway only accepts native tokens from WcBTC
+      // Direct transfers from any other source should be rejected
+      // This is already tested in the Security section
+      // Here we verify the forwarder received the funds (test setup works)
+      expect(await ethers.provider.getBalance(await forwarder.getAddress())).to.equal(ethers.parseEther("1"));
+    });
+  });
+
+  describe("Transfer Failure Handling", function () {
+    it("Should revert with TransferFailed when native token send fails", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      // Deploy contract that rejects native tokens
+      const RejectNativeFactory = await ethers.getContractFactory("RejectNative");
+      const rejecter = await RejectNativeFactory.deploy();
+      await rejecter.waitForDeployment();
+
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Setup position
+      const tokenId = 1;
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      await positionManager.setPositionData(tokenId, token0, token1, 100);
+      await positionManager.setDecreaseResult(ethers.parseEther("100"), ethers.parseEther("1"));
+
+      // Fund position manager with svJUSD
+      await jusd.mint(owner.address, ethers.parseEther("200"));
+      await jusd.connect(owner).approve(await svJusd.getAddress(), ethers.parseEther("200"));
+      await svJusd.connect(owner).deposit(ethers.parseEther("100"), posManagerAddr);
+      await wcbtc.deposit({ value: ethers.parseEther("100") });
+      await wcbtc.transfer(posManagerAddr, ethers.parseEther("100"));
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const deadline = (await time.latest()) + 3600;
+
+      // Try to remove liquidity with native cBTC output to a contract that rejects it
+      await expect(
+        gateway.connect(user1).removeLiquidity(
+          tokenId,
+          0,
+          ethers.ZeroAddress, // Native cBTC output
+          await jusd.getAddress(),
+          0,
+          0,
+          await rejecter.getAddress(), // Recipient that rejects native tokens
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "TransferFailed");
+    });
+  });
+
+  describe("Token Validation Edge Cases", function () {
+    it("Should revert addLiquidity with tokenA == tokenB", async function () {
+      const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await jusd.getAddress(), // Same token
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+    });
+
+    it("Should revert when JUSD and svJUSD are paired (both become svJUSD)", async function () {
+      const { gateway, user1, jusd, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      // Need to get some svJUSD first
+      await jusd.mint(user1.address, amount);
+      await jusd.connect(user1).approve(await svJusd.getAddress(), amount);
+      await svJusd.connect(user1).deposit(amount, user1.address);
+      await svJusd.connect(user1).approve(await gateway.getAddress(), amount);
+
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(), // -> svJUSD internally
+          await svJusd.getAddress(), // stays svJUSD
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+    });
+  });
+
+  describe("Fee Edge Cases Extended", function () {
+    it("Should use DEFAULT_FEE (3000) when fee=0 for swap", async function () {
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      await swapRouter.setSwapOutput(ethers.parseEther("0.5"));
+      await jusd.connect(user1).approve(await gateway.getAddress(), SWAP_AMOUNT);
+
+      // fee = 0 should internally become 3000
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        0, // Should use DEFAULT_FEE
+        SWAP_AMOUNT,
+        0,
+        user1.address,
+        deadline
+      );
+
+      // Verify swap succeeded (implicitly verifies fee was valid)
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should use DEFAULT_FEE (3000) when fee=0 for addLiquidity", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        0, // Should use DEFAULT_FEE
+        0,
+        0,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should accept fee=999999 (just under limit)", async function () {
+      const { gateway, user1, jusd, wcbtc, swapRouter, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      await swapRouter.setSwapOutput(ethers.parseEther("0.5"));
+      await jusd.connect(user1).approve(await gateway.getAddress(), SWAP_AMOUNT);
+
+      // Setup mock factory to accept this fee tier
+      const factoryAddr = await positionManager.factory();
+      const MockFactoryFactory = await ethers.getContractFactory("MockFactory");
+      const factory = MockFactoryFactory.attach(factoryAddr);
+      await factory.enableFeeAmount(999999, 1); // Enable this fee tier
+
+      // This should succeed since 999999 < 1_000_000
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          999999,
+          SWAP_AMOUNT,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should revert with fee > 1000000", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      await jusd.connect(user1).approve(await gateway.getAddress(), SWAP_AMOUNT);
+
+      await expect(
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            1_000_001,
+            SWAP_AMOUNT,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
+    });
+  });
+
+  describe("Tick Spacing per Fee Tier", function () {
+    it("Should accept ticks aligned to spacing=1 for fee=100 (0.01%)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // For fee=100, tickSpacing=1, so any odd tick like -887271 is valid
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        100, // 0.01% fee, tickSpacing=1
+        -887271, // Odd tick, only valid for spacing=1
+        887271,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should accept ticks aligned to spacing=10 for fee=500 (0.05%)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // For fee=500, tickSpacing=10
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        500, // 0.05% fee, tickSpacing=10
+        -60000, // Aligned to 10
+        60000,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should accept ticks aligned to spacing=200 for fee=10000 (1%)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // For fee=10000, tickSpacing=200
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        10000, // 1% fee, tickSpacing=200
+        -60000, // Aligned to 200
+        60000,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should revert ticks not aligned to spacing=10 for fee=500", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // For fee=500, tickSpacing=10, so -60005 is not aligned
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          500,
+          -60005, // NOT aligned to 10
+          60000,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
+
+    it("Should revert ticks not aligned to spacing=200 for fee=10000", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // For fee=10000, tickSpacing=200, so -60060 is not aligned (aligned to 60, not 200)
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          10000,
+          -60060, // Aligned to 60 but NOT to 200
+          60000,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
+  });
+
+  describe("Tick Range Boundaries", function () {
+    const MIN_TICK = -887272;
+    const MAX_TICK = 887272;
+
+    it("Should accept exact MIN_TICK (-887272) when aligned (fee=100, spacing=1)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // With tickSpacing=1 (fee=100), exact MIN_TICK and MAX_TICK are valid
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        100, // tickSpacing=1
+        MIN_TICK,
+        MAX_TICK,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should revert when tickLower < MIN_TICK", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          100,
+          MIN_TICK - 1, // Below MIN_TICK
+          MAX_TICK,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
+
+    it("Should revert when tickUpper > MAX_TICK", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          100,
+          MIN_TICK,
+          MAX_TICK + 1, // Above MAX_TICK
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
+  });
+
+  describe("Negative Tick Alignment", function () {
+    it("Should handle negative ticks correctly aligned to spacing=60", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // -120 is aligned to 60 (even negative)
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        3000, // tickSpacing=60
+        -120, // Aligned to 60
+        120,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should reject misaligned negative ticks", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // -61 % 60 = -1 (not aligned)
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          -61, // Not aligned to 60
+          60,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTickRange");
+    });
+  });
+
+  describe("NFT Recovery Failure Scenarios", function () {
+    it("Should revert if NFT transfer back fails after increaseLiquidity", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      const tokenId = 1;
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      await positionManager.setPositionData(tokenId, token0, token1, 100);
+      await positionManager.setIncreaseResult(50, ethers.parseEther("50"), ethers.parseEther("0.5"));
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      // Configure position manager to fail on safeTransferFrom back to user
+      await positionManager.setFailSafeTransfer(true, "NFT transfer blocked");
+
+      const deadline = (await time.latest()) + 3600;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      await jusd.connect(user1).approve(gatewayAddr, jusdAmount);
+      await wcbtc.connect(user1).approve(gatewayAddr, wcbtcAmount);
+
+      await expect(
+        gateway
+          .connect(user1)
+          .increaseLiquidity(
+            tokenId,
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            jusdAmount,
+            wcbtcAmount,
+            0,
+            0,
+            deadline
+          )
+      ).to.be.reverted; // NFT transfer blocked - any revert is acceptable
+    });
+
+    it("Should revert on non-existent tokenId for increaseLiquidity", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      const nonExistentTokenId = 999999;
+
+      // Should revert because NFT doesn't exist (ownerOf will fail)
+      await expect(
+        gateway
+          .connect(user1)
+          .increaseLiquidity(
+            nonExistentTokenId,
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            amount,
+            amount,
+            0,
+            0,
+            deadline
+          )
+      ).to.be.reverted; // ERC721NonexistentToken
+    });
+
+    it("Should revert on non-existent tokenId for removeLiquidity", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + 3600;
+      const nonExistentTokenId = 999999;
+
+      await expect(
+        gateway
+          .connect(user1)
+          .removeLiquidity(
+            nonExistentTokenId,
+            0,
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.reverted; // ERC721NonexistentToken
+    });
+  });
+
+  describe("Partial Liquidity Edge Cases", function () {
+    it("Should remove exactly all liquidity when liquidityToRemove equals position liquidity", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      const tokenId = 1;
+      const positionLiquidity = 12345; // Specific value
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      await positionManager.setPositionData(tokenId, token0, token1, positionLiquidity);
+      await positionManager.setDecreaseResult(ethers.parseEther("100"), ethers.parseEther("1"));
+
+      // Fund position manager with svJUSD
+      await jusd.mint(owner.address, ethers.parseEther("200"));
+      await jusd.connect(owner).approve(await svJusd.getAddress(), ethers.parseEther("200"));
+      await svJusd.connect(owner).deposit(ethers.parseEther("100"), posManagerAddr);
+      await wcbtc.deposit({ value: ethers.parseEther("100") });
+      await wcbtc.transfer(posManagerAddr, ethers.parseEther("100"));
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const deadline = (await time.latest()) + 3600;
+
+      const tx = await gateway.connect(user1).removeLiquidity(
+        tokenId,
+        positionLiquidity, // Exact match
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityRemoved");
+    });
+
+    it("Should remove minimum liquidity (1 unit)", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      const tokenId = 1;
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      await positionManager.setPositionData(tokenId, token0, token1, 1000);
+      await positionManager.setDecreaseResult(1n, 1n); // Very small amounts
+
+      // Fund position manager with minimal tokens
+      await jusd.mint(owner.address, ethers.parseEther("2"));
+      await jusd.connect(owner).approve(await svJusd.getAddress(), ethers.parseEther("2"));
+      await svJusd.connect(owner).deposit(ethers.parseEther("1"), posManagerAddr);
+      await wcbtc.deposit({ value: ethers.parseEther("1") });
+      await wcbtc.transfer(posManagerAddr, ethers.parseEther("1"));
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const deadline = (await time.latest()) + 3600;
+
+      const tx = await gateway.connect(user1).removeLiquidity(
+        tokenId,
+        1, // Minimum liquidity
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityRemoved");
+
+      // NFT should still be owned by user (partial removal)
+      expect(await positionManager.ownerOf(tokenId)).to.equal(user1.address);
+    });
+
+    it("Should revert when liquidityToRemove = type(uint128).max exceeds position", async function () {
+      const { gateway, user1, owner, svJusd, wcbtc, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const gatewayAddr = await gateway.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      const tokenId = 1;
+      const positionLiquidity = 1000;
+      const maxUint128 = 2n ** 128n - 1n;
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      await positionManager.setPositionData(tokenId, token0, token1, positionLiquidity);
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const deadline = (await time.latest()) + 3600;
+
+      await expect(
+        gateway.connect(user1).removeLiquidity(
+          tokenId,
+          maxUint128,
+          await svJusd.getAddress(), // Use actual pool tokens
+          await wcbtc.getAddress(),
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientLiquidity");
+    });
+  });
+
+  describe("Sequential Operations on Same Position", function () {
+    it("Should complete full lifecycle: Add -> Increase -> Remove", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + 3600;
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      // Step 1: Add liquidity
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+      await jusd.connect(user1).approve(gatewayAddr, jusdAmount * 3n);
+      await wcbtc.connect(user1).approve(gatewayAddr, wcbtcAmount * 3n);
+
+      const addTx = await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(addTx).to.emit(gateway, "LiquidityAdded");
+      const tokenId = 1;
+      expect(await positionManager.ownerOf(tokenId)).to.equal(user1.address);
+
+      // Step 2: Increase liquidity
+      await positionManager.setPositionData(tokenId, token0, token1, 100);
+      await positionManager.setIncreaseResult(50, amount0 / 2n, amount1 / 2n);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const increaseTx = await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          tokenId,
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          deadline
+        );
+
+      await expect(increaseTx).to.emit(gateway, "LiquidityIncreased");
+      expect(await positionManager.ownerOf(tokenId)).to.equal(user1.address);
+
+      // Step 3: Remove all liquidity
+      await positionManager.setPositionData(tokenId, token0, token1, 150);
+      await positionManager.setDecreaseResult((amount0 * 3n) / 2n, (amount1 * 3n) / 2n);
+
+      // Fund position manager with svJUSD
+      await jusd.mint(owner.address, ethers.parseEther("400"));
+      await jusd.connect(owner).approve(await svJusd.getAddress(), ethers.parseEther("400"));
+      await svJusd.connect(owner).deposit(ethers.parseEther("200"), posManagerAddr);
+      await wcbtc.deposit({ value: ethers.parseEther("200") });
+      await wcbtc.transfer(posManagerAddr, ethers.parseEther("200"));
+
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const removeTx = await gateway.connect(user1).removeLiquidity(
+        tokenId,
+        0, // Remove all
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(removeTx).to.emit(gateway, "LiquidityRemoved");
+    });
+  });
+
+  describe("Slippage Protection Boundary Cases", function () {
+    it("Should succeed when actual amounts exactly equal min amounts (removeLiquidity)", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      const tokenId = 1;
+      const exactJusdAmount = ethers.parseEther("100");
+      const exactWcbtcAmount = ethers.parseEther("1");
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      // Note: For JUSD output, we receive svJUSD internally which gets converted to JUSD
+      // The min check happens AFTER conversion
+      const svJusdShares = await svJusd.convertToShares(exactJusdAmount);
+      const [amount0, amount1] =
+        svJusdAddr < wcbtcAddr ? [svJusdShares, exactWcbtcAmount] : [exactWcbtcAmount, svJusdShares];
+
+      await positionManager.setPositionData(tokenId, token0, token1, 100);
+      await positionManager.setDecreaseResult(amount0, amount1);
+
+      // Fund position manager with svJUSD
+      await jusd.mint(owner.address, exactJusdAmount * 4n);
+      await jusd.connect(owner).approve(await svJusd.getAddress(), exactJusdAmount * 4n);
+      await svJusd.connect(owner).deposit(exactJusdAmount * 2n, posManagerAddr);
+      await wcbtc.deposit({ value: exactWcbtcAmount * 2n });
+      await wcbtc.transfer(posManagerAddr, exactWcbtcAmount * 2n);
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const deadline = (await time.latest()) + 3600;
+
+      // Set min amounts to exactly what we expect to receive
+      const tx = await gateway.connect(user1).removeLiquidity(
+        tokenId,
+        0,
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        exactJusdAmount, // Exact match
+        exactWcbtcAmount, // Exact match
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityRemoved");
+    });
+
+    it("Should revert when actual amount is below min (removeLiquidity)", async function () {
+      const { gateway, user1, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const gatewayAddr = await gateway.getAddress();
+      const posManagerAddr = await positionManager.getAddress();
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      const tokenId = 1;
+      const actualJusdAmount = ethers.parseEther("99");
+      const actualWcbtcAmount = ethers.parseEther("1");
+      const minJusdAmount = ethers.parseEther("100"); // More than actual
+      const [token0, token1] = svJusdAddr < wcbtcAddr ? [svJusdAddr, wcbtcAddr] : [wcbtcAddr, svJusdAddr];
+
+      const svJusdShares = await svJusd.convertToShares(actualJusdAmount);
+      const [amount0, amount1] =
+        svJusdAddr < wcbtcAddr ? [svJusdShares, actualWcbtcAmount] : [actualWcbtcAmount, svJusdShares];
+
+      await positionManager.setPositionData(tokenId, token0, token1, 100);
+      await positionManager.setDecreaseResult(amount0, amount1);
+
+      // Fund position manager with svJUSD
+      await jusd.mint(owner.address, actualJusdAmount * 4n);
+      await jusd.connect(owner).approve(await svJusd.getAddress(), actualJusdAmount * 4n);
+      await svJusd.connect(owner).deposit(actualJusdAmount * 2n, posManagerAddr);
+      await wcbtc.deposit({ value: actualWcbtcAmount * 2n });
+      await wcbtc.transfer(posManagerAddr, actualWcbtcAmount * 2n);
+
+      await positionManager.mintNFT(user1.address, tokenId);
+      await positionManager.connect(user1).approve(gatewayAddr, tokenId);
+
+      const deadline = (await time.latest()) + 3600;
+
+      await expect(
+        gateway.connect(user1).removeLiquidity(
+          tokenId,
+          0,
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          minJusdAmount, // More than we'll receive
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+    });
+  });
+
+  describe("Precision Edge Cases", function () {
+    it("Should handle very small bridged token amounts (precision loss in 6->18 conversion)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      // Deploy bridged token with 6 decimals
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+      await usdc.waitForDeployment();
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"), // limit
+        Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60 // horizon
+      );
+      await usdcBridge.waitForDeployment();
+
+      // Setup bridge as minter
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      // Test with 1 unit of USDC (0.000001 USDC = 1e12 wei JUSD)
+      const tinyUsdcAmount = 1n; // 1 wei of USDC (6 decimals) = 0.000001 USDC
+      const expectedJusdAmount = tinyUsdcAmount * 10n ** 12n; // 1e12 wei JUSD
+
+      await usdc.mint(user1.address, tinyUsdcAmount);
+      await usdc.connect(user1).approve(await gateway.getAddress(), tinyUsdcAmount);
+      await usdcBridge.setMinted(expectedJusdAmount);
+
+      // Setup swap output
+      await swapRouter.setSwapOutput(ethers.parseEther("0.0001"));
+
+      const deadline = (await time.latest()) + 3600;
+
+      // This tests that very small amounts don't cause issues
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          tinyUsdcAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+  });
+
+  describe("Large Amount Edge Cases", function () {
+    it("Should handle large but valid amounts without overflow", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Use a large amount (but not so large it overflows when converted)
+      const largeAmount = ethers.parseEther("1000000000"); // 1 billion
+
+      await jusd.mint(user1.address, largeAmount);
+      await jusd.connect(user1).approve(await gateway.getAddress(), largeAmount);
+      await swapRouter.setSwapOutput(ethers.parseEther("1000"));
+
+      const deadline = (await time.latest()) + 3600;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          largeAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+  });
+
+  // ==================== Additional Coverage Tests ====================
+
+  describe("createPoolAndAddLiquidity Extended", function () {
+    it("Should return excess tokens when position manager uses less", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("100");
+
+      // Setup mock to use less than desired (50% of each)
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const usedAmount0 = svJusdAddr < wcbtcAddr ? svJusdShares / 2n : wcbtcAmount / 2n;
+      const usedAmount1 = svJusdAddr < wcbtcAddr ? wcbtcAmount / 2n : svJusdShares / 2n;
+
+      await positionManager.setMintResult(1, 100, usedAmount0, usedAmount1);
+
+      // Approve tokens
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      const jusdBefore = await jusd.balanceOf(user1.address);
+      const wcbtcBefore = await wcbtc.balanceOf(user1.address);
+
+      await gateway
+        .connect(user1)
+        .createPoolAndAddLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          sqrtPriceX96,
+          0,
+          0,
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      // User should get excess back (approximately half)
+      const jusdAfter = await jusd.balanceOf(user1.address);
+      const wcbtcAfter = await wcbtc.balanceOf(user1.address);
+
+      // User paid jusdAmount but got some back
+      expect(jusdBefore - jusdAfter).to.be.lessThan(jusdAmount);
+      expect(wcbtcBefore - wcbtcAfter).to.be.lessThan(wcbtcAmount);
+    });
+
+    it("Should revert for same token pair", async function () {
+      const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+      const amount = ethers.parseEther("100");
+
+      await expect(
+        gateway
+          .connect(user1)
+          .createPoolAndAddLiquidity(
+            await jusd.getAddress(),
+            await jusd.getAddress(),
+            3000,
+            sqrtPriceX96,
+            0,
+            0,
+            amount,
+            amount,
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+    });
+
+    it("Should revert for invalid fee", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+      const amount = ethers.parseEther("100");
+
+      await expect(
+        gateway.connect(user1).createPoolAndAddLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          1000000, // Invalid: >= 1_000_000
+          sqrtPriceX96,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
+    });
+
+    it("Should work with custom tick ranges", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("100");
+
+      // Custom tick range aligned to tickSpacing=60 for fee=3000
+      const tickLower = -600;
+      const tickUpper = 600;
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      const tx = await gateway
+        .connect(user1)
+        .createPoolAndAddLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          sqrtPriceX96,
+          tickLower,
+          tickUpper,
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "PoolCreated");
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should work with native cBTC input", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+      const jusdAmount = ethers.parseEther("100");
+      const nativeAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, nativeAmount] : [nativeAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 100, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+
+      const tx = await gateway.connect(user1).createPoolAndAddLiquidity(
+        await jusd.getAddress(),
+        ethers.ZeroAddress, // Native cBTC
+        3000,
+        sqrtPriceX96,
+        0,
+        0,
+        jusdAmount,
+        nativeAmount,
+        0,
+        0,
+        user1.address,
+        deadline,
+        { value: nativeAmount }
+      );
+
+      await expect(tx).to.emit(gateway, "PoolCreated");
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should revert with InvalidPrice for zero sqrtPriceX96", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      await expect(
+        gateway.connect(user1).createPoolAndAddLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0, // Invalid: zero price
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidPrice");
+    });
+  });
+
+  describe("Price Math Tests", function () {
+    it("Should handle price conversion with high share price (1 svJUSD = 2 JUSD)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Simulate 100% interest accrual (1 svJUSD = 2 JUSD)
+      await svJusd.accrueInterest(ethers.parseEther("100"));
+
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // 1:1 in JUSD terms
+
+      // This tests _convertSqrtPrice with a significant share price difference
+      const tx = await gateway
+        .connect(user1)
+        .createPool(await jusd.getAddress(), await wcbtc.getAddress(), 3000, sqrtPriceX96);
+
+      await expect(tx).to.emit(gateway, "PoolCreated");
+    });
+
+    it("Should handle price conversion when token1 is JUSD-based", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Simulate interest
+      await svJusd.accrueInterest(ethers.parseEther("10"));
+
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+      // WcBTC < svJUSD in address ordering, so JUSD becomes token1
+      // This tests _divSqrtPrice path
+      const tx = await gateway
+        .connect(user1)
+        .createPool(await wcbtc.getAddress(), await jusd.getAddress(), 3000, sqrtPriceX96);
+
+      await expect(tx).to.emit(gateway, "PoolCreated");
+    });
+
+    it("Should handle very small sqrt prices", async function () {
+      const { gateway, user1, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Very small price (close to minimum)
+      const smallSqrtPrice = BigInt("7922816251426433759"); // ~0.0001 price
+
+      const tx = await gateway
+        .connect(user1)
+        .createPool(await juice.getAddress(), await wcbtc.getAddress(), 3000, smallSqrtPrice);
+
+      await expect(tx).to.emit(gateway, "PoolCreated");
+    });
+
+    it("Should handle large sqrt prices", async function () {
+      const { gateway, user1, juice, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Large price (but not overflow)
+      const largeSqrtPrice = BigInt("79228162514264337593543950336000"); // 1000:1 price
+
+      const tx = await gateway
+        .connect(user1)
+        .createPool(await juice.getAddress(), await wcbtc.getAddress(), 3000, largeSqrtPrice);
+
+      await expect(tx).to.emit(gateway, "PoolCreated");
+    });
+  });
+
+  describe("JUICE Edge Cases", function () {
+    it("Should swap JUICE to native cBTC output", async function () {
+      const { gateway, user1, juice, wcbtc, jusd, svJusd, swapRouter } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const juiceAmount = ethers.parseEther("100");
+      const expectedOutput = ethers.parseEther("1");
+
+      // Fund JUSD to juice contract for redeem (JUICE redeems to JUSD at 100:1 ratio)
+      // 100 JUICE = 10000 JUSD (PRICE = 100e18)
+      const jusdForRedeem = ethers.parseEther("10000");
+      await jusd.mint(await juice.getAddress(), jusdForRedeem);
+
+      // Setup swap output
+      await swapRouter.setSwapOutput(expectedOutput);
+
+      // Fund wcbtc to swap router for output
+      await wcbtc.deposit({ value: expectedOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 2n);
+
+      await juice.connect(user1).approve(await gateway.getAddress(), juiceAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        await juice.getAddress(),
+        ethers.ZeroAddress, // Native cBTC output
+        3000,
+        juiceAmount,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should swap native cBTC to JUICE output", async function () {
+      const { gateway, user1, juice, wcbtc, jusd, svJusd, swapRouter } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const nativeAmount = ethers.parseEther("1");
+      const svJusdOutput = ethers.parseEther("50000"); // svJUSD output from swap
+
+      // Setup swap output (svJUSD)
+      await swapRouter.setSwapOutput(svJusdOutput);
+
+      // Fund svJUSD to swap router via deposit (use explicit function signature)
+      await jusd.mint(await svJusd.getAddress(), svJusdOutput * 2n);
+      await svJusd["mint(address,uint256)"](await swapRouter.getAddress(), svJusdOutput * 2n);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        ethers.ZeroAddress, // Native cBTC input
+        await juice.getAddress(),
+        3000,
+        nativeAmount,
+        0,
+        user1.address,
+        deadline,
+        { value: nativeAmount }
+      );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should handle JUICE with maximum slippage check", async function () {
+      const { gateway, user1, juice, wcbtc, jusd, svJusd, swapRouter } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const juiceAmount = ethers.parseEther("100");
+      const minOutput = ethers.parseEther("0.5"); // Set minimum
+      const actualOutput = ethers.parseEther("0.6"); // Above minimum
+
+      // Fund JUSD to juice contract for redeem
+      const jusdForRedeem = ethers.parseEther("10000");
+      await jusd.mint(await juice.getAddress(), jusdForRedeem);
+
+      await swapRouter.setSwapOutput(actualOutput);
+
+      // Fund wcbtc
+      await wcbtc.deposit({ value: actualOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), actualOutput * 2n);
+
+      await juice.connect(user1).approve(await gateway.getAddress(), juiceAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await juice.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          juiceAmount,
+          minOutput,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+  });
+
+  describe("Bridge Failure Scenarios", function () {
+    it("Should revert when bridge mint limit is exceeded", async function () {
+      const { gateway, owner, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy a bridged token with very low limit
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdt = (await MockERC20Factory.deploy("Tether USD", "USDT", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const lowLimitBridge = await MockBridgeFactory.deploy(
+        await usdt.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("100"), // Very low limit: 100 JUSD
+        52
+      );
+
+      // Setup JUSD to accept bridge as minter
+      await jusd.setMinter(await lowLimitBridge.getAddress(), true);
+
+      // Register bridge
+      await gateway.registerBridgedToken(await lowLimitBridge.getAddress());
+
+      // Mint USDT to user (more than limit)
+      const usdtAmount = 200_000000n; // 200 USDT (6 decimals) = 200 JUSD > 100 limit
+      await usdt.mint(user1.address, usdtAmount);
+      await usdt.connect(user1).approve(await gateway.getAddress(), usdtAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      // Should fail due to LimitExceeded
+      await expect(
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await usdt.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            usdtAmount,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(lowLimitBridge, "LimitExceeded");
+    });
+
+    it("Should revert when bridge is expired", async function () {
+      const { gateway, owner, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy a bridged token with very short expiry
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdt = (await MockERC20Factory.deploy("Tether USD", "USDT", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const expiringBridge = await MockBridgeFactory.deploy(
+        await usdt.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        1 // 1 week expiry
+      );
+
+      // Setup JUSD to accept bridge as minter
+      await jusd.setMinter(await expiringBridge.getAddress(), true);
+
+      // Register bridge
+      await gateway.registerBridgedToken(await expiringBridge.getAddress());
+
+      // Mint USDT to user
+      const usdtAmount = 100_000000n; // 100 USDT
+      await usdt.mint(user1.address, usdtAmount);
+      await usdt.connect(user1).approve(await gateway.getAddress(), usdtAmount);
+
+      // Fast forward past expiry (2 weeks)
+      await time.increase(2 * 7 * 24 * 60 * 60);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      // Should fail due to Expired
+      await expect(
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await usdt.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            usdtAmount,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWithCustomError(expiringBridge, "Expired");
+    });
+  });
+
+  describe("View Function Edge Cases", function () {
+    it("Should return correct values for jusdToSvJusd with zero amount", async function () {
+      const { gateway } = await loadFixture(deployGatewayFixture);
+
+      const result = await gateway.jusdToSvJusd(0);
+      expect(result).to.equal(0);
+    });
+
+    it("Should return correct values for svJusdToJusd with zero amount", async function () {
+      const { gateway } = await loadFixture(deployGatewayFixture);
+
+      const result = await gateway.svJusdToJusd(0);
+      expect(result).to.equal(0);
+    });
+
+    it("Should return correct values for juiceToJusd with zero amount", async function () {
+      const { gateway } = await loadFixture(deployGatewayFixture);
+
+      // calculateProceeds(0) returns 0 automatically
+      const result = await gateway.juiceToJusd(0);
+      expect(result).to.equal(0);
+    });
+
+    it("Should return false for isBridgedToken with non-bridged token", async function () {
+      const { gateway, wcbtc } = await loadFixture(deployGatewayFixture);
+
+      const result = await gateway.isBridgedToken(await wcbtc.getAddress());
+      expect(result).to.be.false;
+    });
+
+    it("Should return empty array for getBridgedTokens when none registered", async function () {
+      const { gateway } = await loadFixture(deployGatewayFixture);
+
+      const result = await gateway.getBridgedTokens();
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe("Sequential Operations", function () {
+    it("Should handle add -> increase -> partial remove -> increase -> full remove", async function () {
+      const { gateway, owner, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET * 10; // Long deadline
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      // Step 1: Add liquidity
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount * 5n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount * 5n);
+
+      await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      // NFT (tokenId=1) is already minted to user1 by addLiquidity
+      const posManagerAddr = await positionManager.getAddress();
+      const gatewayAddr = await gateway.getAddress();
+
+      // Approve gateway to transfer NFT for all increase/remove operations
+      await positionManager.connect(user1).setApprovalForAll(gatewayAddr, true);
+
+      // Step 2: Increase liquidity
+      await positionManager.setIncreaseResult(500, amount0 / 2n, amount1 / 2n);
+
+      await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          1,
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          jusdAmount / 2n,
+          wcbtcAmount / 2n,
+          0,
+          0,
+          deadline
+        );
+
+      // Step 3: Partial remove (500 of 1500 liquidity)
+      await positionManager.setDecreaseResult(amount0 / 3n, amount1 / 3n);
+
+      // Fund position manager for returns
+      await jusd.mint(owner.address, jusdAmount);
+      await jusd.connect(owner).approve(await svJusd.getAddress(), jusdAmount);
+      await svJusd.connect(owner).deposit(jusdAmount, posManagerAddr);
+      await wcbtc.deposit({ value: wcbtcAmount });
+      await wcbtc.transfer(posManagerAddr, wcbtcAmount);
+
+      await gateway
+        .connect(user1)
+        .removeLiquidity(1, 500, await jusd.getAddress(), await wcbtc.getAddress(), 0, 0, user1.address, deadline);
+
+      // Step 4: Increase again
+      await positionManager.setIncreaseResult(300, amount0 / 4n, amount1 / 4n);
+
+      await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          1,
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          jusdAmount / 4n,
+          wcbtcAmount / 4n,
+          0,
+          0,
+          deadline
+        );
+
+      // Step 5: Full remove (liquidityToRemove = 0 means all)
+      await positionManager.setDecreaseResult(amount0, amount1);
+
+      // Fund more for full removal
+      await jusd.mint(owner.address, jusdAmount * 2n);
+      await jusd.connect(owner).approve(await svJusd.getAddress(), jusdAmount * 2n);
+      await svJusd.connect(owner).deposit(jusdAmount * 2n, posManagerAddr);
+      await wcbtc.deposit({ value: wcbtcAmount * 2n });
+      await wcbtc.transfer(posManagerAddr, wcbtcAmount * 2n);
+
+      const tx = await gateway.connect(user1).removeLiquidity(
+        1,
+        0, // Remove all
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityRemoved");
+    });
+  });
+
+  // ==================== Final Coverage Tests ====================
+
+  describe("getPool Extended Tests", function () {
+    it("Should find JUICE/WcBTC pool", async function () {
+      const { gateway, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const juiceAddr = await juice.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const mockPoolAddr = "0x" + "1".repeat(40);
+
+      // Get factory from position manager and set pool
+      const factoryAddr = await positionManager.factory();
+      const factory = await ethers.getContractAt("MockFactory", factoryAddr);
+      await factory.setPool(juiceAddr, wcbtcAddr, 3000, mockPoolAddr);
+
+      // JUICE stays JUICE for liquidity lookup
+      const [pool, exists] = await gateway.getPool(await juice.getAddress(), await wcbtc.getAddress(), 3000);
+
+      expect(exists).to.be.true;
+      expect(pool.toLowerCase()).to.equal(mockPoolAddr.toLowerCase());
+    });
+
+    it("Should find pool with bridged token", async function () {
+      const { gateway, owner, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      // Deploy and register bridged token
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      // Set up pool with svJUSD (bridged token converts to svJUSD)
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const mockPoolAddr = "0x" + "2".repeat(40);
+
+      const factoryAddr = await positionManager.factory();
+      const factory = await ethers.getContractAt("MockFactory", factoryAddr);
+      await factory.setPool(svJusdAddr, wcbtcAddr, 3000, mockPoolAddr);
+
+      // Query with bridged token should find svJUSD pool
+      const [pool, exists] = await gateway.getPool(await usdc.getAddress(), await wcbtc.getAddress(), 3000);
+
+      expect(exists).to.be.true;
+      expect(pool.toLowerCase()).to.equal(mockPoolAddr.toLowerCase());
+    });
+
+    it("Should find pool with native cBTC (zero address)", async function () {
+      const { gateway, jusd, wcbtc, svJusd, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const mockPoolAddr = "0x" + "3".repeat(40);
+
+      const factoryAddr = await positionManager.factory();
+      const factory = await ethers.getContractAt("MockFactory", factoryAddr);
+      await factory.setPool(svJusdAddr, wcbtcAddr, 3000, mockPoolAddr);
+
+      // Query with native cBTC (zero address) should find WcBTC pool
+      const [pool, exists] = await gateway.getPool(await jusd.getAddress(), ethers.ZeroAddress, 3000);
+
+      expect(exists).to.be.true;
+      expect(pool.toLowerCase()).to.equal(mockPoolAddr.toLowerCase());
+    });
+
+    it("Should find pool with different fee tiers", async function () {
+      const { gateway, jusd, wcbtc, svJusd, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      const factoryAddr = await positionManager.factory();
+      const factory = await ethers.getContractAt("MockFactory", factoryAddr);
+
+      // Set pools for different fee tiers
+      const pool100 = "0x" + "a".repeat(40);
+      const pool500 = "0x" + "b".repeat(40);
+      const pool10000 = "0x" + "c".repeat(40);
+
+      await factory.setPool(svJusdAddr, wcbtcAddr, 100, pool100);
+      await factory.setPool(svJusdAddr, wcbtcAddr, 500, pool500);
+      await factory.setPool(svJusdAddr, wcbtcAddr, 10000, pool10000);
+
+      // Query each fee tier
+      const [p100, e100] = await gateway.getPool(await jusd.getAddress(), await wcbtc.getAddress(), 100);
+      const [p500, e500] = await gateway.getPool(await jusd.getAddress(), await wcbtc.getAddress(), 500);
+      const [p10000, e10000] = await gateway.getPool(await jusd.getAddress(), await wcbtc.getAddress(), 10000);
+
+      expect(e100).to.be.true;
+      expect(p100.toLowerCase()).to.equal(pool100.toLowerCase());
+      expect(e500).to.be.true;
+      expect(p500.toLowerCase()).to.equal(pool500.toLowerCase());
+      expect(e10000).to.be.true;
+      expect(p10000.toLowerCase()).to.equal(pool10000.toLowerCase());
+    });
+  });
+
+  describe("Position Manager Failure Scenarios", function () {
+    it("Should revert when Position Manager mint fails", async function () {
+      const { gateway, user1, jusd, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // Set mint to fail
+      await positionManager.setFailNextMint(true, "Mint failed: insufficient liquidity");
+
+      await expect(
+        gateway
+          .connect(user1)
+          .addLiquidity(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            0,
+            0,
+            amount,
+            amount,
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWith("Mint failed: insufficient liquidity");
+    });
+
+    it("Should revert when Position Manager increaseLiquidity fails", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      // First create a position
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(amount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      // Approve gateway for NFT operations
+      await positionManager.connect(user1).setApprovalForAll(await gateway.getAddress(), true);
+
+      // Set increaseLiquidity to fail
+      await positionManager.setFailNextIncrease(true, "Increase failed: pool locked");
+
+      await expect(
+        gateway
+          .connect(user1)
+          .increaseLiquidity(1, await jusd.getAddress(), await wcbtc.getAddress(), amount, amount, 0, 0, deadline)
+      ).to.be.revertedWith("Increase failed: pool locked");
+    });
+
+    it("Should revert when Position Manager decreaseLiquidity fails", async function () {
+      const { gateway, owner, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      // First create a position
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(amount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      // Approve gateway for NFT operations
+      await positionManager.connect(user1).setApprovalForAll(await gateway.getAddress(), true);
+
+      // Set decreaseLiquidity to fail
+      await positionManager.setFailNextDecrease(true, "Decrease failed: position locked");
+
+      await expect(
+        gateway
+          .connect(user1)
+          .removeLiquidity(1, 500, await jusd.getAddress(), await wcbtc.getAddress(), 0, 0, user1.address, deadline)
+      ).to.be.revertedWith("Decrease failed: position locked");
+    });
+
+    it("Should revert when createPoolAndAddLiquidity mint fails", async function () {
+      const { gateway, user1, jusd, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+      const amount = ethers.parseEther("100");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // Set mint to fail
+      await positionManager.setFailNextMint(true, "Pool creation failed");
+
+      await expect(
+        gateway
+          .connect(user1)
+          .createPoolAndAddLiquidity(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            sqrtPriceX96,
+            0,
+            0,
+            amount,
+            amount,
+            0,
+            0,
+            user1.address,
+            deadline
+          )
+      ).to.be.revertedWith("Pool creation failed");
+    });
+  });
+
+  describe("Extreme Values and Overflow Tests", function () {
+    it("Should handle very small liquidity amounts (1 wei)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const tinyAmount = 1n; // 1 wei
+
+      // Mint tiny amounts
+      await jusd.mint(user1.address, tinyAmount);
+      await wcbtc.deposit({ value: tinyAmount });
+      await wcbtc.transfer(user1.address, tinyAmount);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), tinyAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), tinyAmount);
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [tinyAmount, tinyAmount] : [tinyAmount, tinyAmount];
+
+      await positionManager.setMintResult(1, 1, amount0, amount1);
+
+      const tx = await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          tinyAmount,
+          tinyAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should handle maximum uint128 liquidity in position", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      // Set position with max uint128 liquidity
+      const maxUint128 = 2n ** 128n - 1n;
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(amount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
+
+      await positionManager.setMintResult(1, maxUint128, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount);
+
+      const tx = await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should handle swap with very high share price (1 svJUSD = 10 JUSD)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Simulate massive interest accrual (1 svJUSD = 10 JUSD)
+      await svJusd.accrueInterest(ethers.parseEther("900")); // 9x increase on top of base 100
+
+      const jusdAmount = ethers.parseEther("100");
+      const expectedOutput = ethers.parseEther("1");
+
+      await swapRouter.setSwapOutput(expectedOutput);
+      await wcbtc.deposit({ value: expectedOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 2n);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          jusdAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should create pool with high share price price conversion", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Simulate 5x share price (1 svJUSD = 5 JUSD)
+      await svJusd.accrueInterest(ethers.parseEther("400"));
+
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // 1:1 in JUSD terms
+
+      // This tests _mulSqrtPrice with high factor
+      const tx = await gateway
+        .connect(user1)
+        .createPool(await jusd.getAddress(), await wcbtc.getAddress(), 3000, sqrtPriceX96);
+
+      await expect(tx).to.emit(gateway, "PoolCreated");
+    });
+
+    it("Should handle bridged token with maximum precision loss (1 wei bridged = 1e12 wei JUSD)", async function () {
+      const { gateway, owner, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy 6-decimal bridged token
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      // Swap exactly 1 wei of USDC (minimum amount)
+      const minUsdcAmount = 1n; // 1 wei = 0.000001 USDC
+      await usdc.mint(user1.address, minUsdcAmount);
+      await usdc.connect(user1).approve(await gateway.getAddress(), minUsdcAmount);
+
+      // Bridge mints 1e12 wei JUSD for 1 wei USDC
+      await usdcBridge.setMinted(10n ** 12n);
+      await swapRouter.setSwapOutput(1n);
+
+      // Fund wcbtc for swap output
+      await wcbtc.deposit({ value: ethers.parseEther("1") });
+      await wcbtc.transfer(await swapRouter.getAddress(), ethers.parseEther("1"));
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          minUsdcAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+  });
+
+  describe("getBridgeStatus Extended", function () {
+    it("Should return correct status for bridge with partial capacity used", async function () {
+      const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy bridged token with known limit
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+
+      const limit = ethers.parseEther("1000"); // 1000 JUSD limit
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(await usdc.getAddress(), await jusd.getAddress(), limit, 52);
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      // Simulate 50% capacity used
+      await usdcBridge.setMinted(limit / 2n);
+
+      const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+      // BridgeStatus returns: canMint, canBurn, mintCapacity, burnCapacity, mintBlockReason, burnBlockReason
+      expect(status.canMint).to.be.true;
+      expect(status.mintCapacity).to.equal(limit / 2n);
+      expect(status.mintBlockReason).to.equal("");
+    });
+
+    it("Should return canMint=false when bridge is expired", async function () {
+      const { gateway, owner, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy bridged token with short expiry
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        1 // 1 week
+      );
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      // Fast forward past expiry
+      await time.increase(2 * 7 * 24 * 60 * 60); // 2 weeks
+
+      const status = await gateway.getBridgeStatus(await usdc.getAddress());
+
+      expect(status.canMint).to.be.false;
+      expect(status.mintBlockReason).to.equal("Bridge expired");
+    });
+  });
+
+  // ==================== Direct USD Conversion Tests ====================
+
+  describe("Direct USD Conversion Paths", function () {
+    it("Should convert JUSD to JUSD directly (no-op)", async function () {
+      const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const amount = ethers.parseEther("100");
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const balanceBefore = await jusd.balanceOf(user1.address);
+
+      const tx = await gateway.connect(user1).swapExactTokensForTokens(
+        await jusd.getAddress(),
+        await jusd.getAddress(),
+        3000,
+        amount,
+        amount, // Expect full amount back
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+      const balanceAfter = await jusd.balanceOf(user1.address);
+      expect(balanceAfter).to.equal(balanceBefore); // No change
+    });
+
+    it("Should convert Bridged token to JUSD via direct path", async function () {
+      const { gateway, owner, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy and register bridged token
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      // USDC has 6 decimals, so 100 USDC = 100_000000
+      const usdcAmount = 100_000000n;
+      const expectedJusd = ethers.parseEther("100"); // 100 JUSD (18 decimals)
+
+      await usdc.mint(user1.address, usdcAmount);
+      await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await jusd.getAddress(),
+          3000,
+          usdcAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+      expect(await jusd.balanceOf(user1.address)).to.be.gte(expectedJusd);
+    });
+
+    it("Should convert Bridged token to JUICE via direct path", async function () {
+      const { gateway, owner, user1, jusd, juice } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy and register bridged token
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      const usdcAmount = 100_000000n; // 100 USDC
+
+      await usdc.mint(user1.address, usdcAmount);
+      await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const juiceBefore = await juice.balanceOf(user1.address);
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await juice.getAddress(),
+          3000,
+          usdcAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+      expect(await juice.balanceOf(user1.address)).to.be.gt(juiceBefore);
+    });
+
+    it("Should convert Bridged token to another Bridged token via direct path", async function () {
+      const { gateway, owner, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy two bridged tokens
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+      const usdt = (await MockERC20Factory.deploy("Tether USD", "USDT", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+      const usdtBridge = await MockBridgeFactory.deploy(
+        await usdt.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await jusd.setMinter(await usdtBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+      await gateway.registerBridgedToken(await usdtBridge.getAddress());
+
+      // Fund USDT bridge with USDT for burn operations
+      const usdtAmount = 100_000000n;
+      await usdt.mint(await usdtBridge.getAddress(), usdtAmount * 10n);
+      // Set minted amount so burn doesn't underflow
+      await usdtBridge.setMinted(ethers.parseEther("1000"));
+
+      // Mint USDC to user
+      const usdcAmount = 100_000000n;
+      await usdc.mint(user1.address, usdcAmount);
+      await usdc.connect(user1).approve(await gateway.getAddress(), usdcAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await usdc.getAddress(),
+          await usdt.getAddress(),
+          3000,
+          usdcAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+      // User should receive approximately same amount in USDT
+      expect(await usdt.balanceOf(user1.address)).to.be.gte(usdcAmount - 1n);
+    });
+
+    it("Should convert JUSD to Bridged token via direct path", async function () {
+      const { gateway, owner, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Deploy and register bridged token
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = (await MockERC20Factory.deploy("USD Coin", "USDC", 6)) as unknown as MockERC20;
+
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const usdcBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+      await jusd.setMinter(await usdcBridge.getAddress(), true);
+      await gateway.registerBridgedToken(await usdcBridge.getAddress());
+
+      // Fund bridge with USDC for burn operations
+      await usdc.mint(await usdcBridge.getAddress(), 1000_000000n);
+      // Set minted amount so burn doesn't underflow
+      await usdcBridge.setMinted(ethers.parseEther("1000"));
+
+      const jusdAmount = ethers.parseEther("100");
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await usdc.getAddress(),
+          3000,
+          jusdAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+      // 100 JUSD should give ~100 USDC (100_000000 in 6 decimals)
+      expect(await usdc.balanceOf(user1.address)).to.be.gte(99_000000n);
+    });
+  });
+
+  describe("Same Token Edge Cases", function () {
+    it("Should handle svJUSD to svJUSD swap (same actual token)", async function () {
+      const { gateway, user1, svJusd, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Both JUSD inputs convert to svJUSD, so this tests the actualTokenIn == actualTokenOut path
+      // But this should be handled by direct USD conversion
+      const amount = ethers.parseEther("100");
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      // JUSD -> JUSD is a direct conversion, not going through swap
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await jusd.getAddress(),
+          3000,
+          amount,
+          amount,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+  });
+
+  describe("Token Allowance Edge Cases", function () {
+    it("Should handle exact allowance (no excess)", async function () {
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const exactAmount = ethers.parseEther("50");
+      const expectedOutput = ethers.parseEther("1");
+
+      // Approve exactly the amount needed
+      await jusd.connect(user1).approve(await gateway.getAddress(), exactAmount);
+      await swapRouter.setSwapOutput(expectedOutput);
+
+      // Fund wcbtc for swap output
+      await wcbtc.deposit({ value: expectedOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 2n);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          exactAmount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should handle multiple sequential swaps with same approval", async function () {
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const swapAmount = ethers.parseEther("10");
+      const expectedOutput = ethers.parseEther("0.1");
+
+      // Approve enough for multiple swaps
+      await jusd.connect(user1).approve(await gateway.getAddress(), swapAmount * 5n);
+      await swapRouter.setSwapOutput(expectedOutput);
+
+      // Fund wcbtc for swap outputs
+      await wcbtc.deposit({ value: expectedOutput * 10n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 10n);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      // Execute 3 sequential swaps
+      for (let i = 0; i < 3; i++) {
+        const tx = await gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            swapAmount,
+            0,
+            user1.address,
+            deadline
+          );
+        await expect(tx).to.emit(gateway, "SwapExecuted");
+      }
+    });
+  });
+
+  describe("Liquidity Position Edge Cases", function () {
+    it("Should handle position with tokens in reverse order (B < A)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Call with WcBTC first (reverse order)
+      const tx = await gateway.connect(user1).addLiquidity(
+        await wcbtc.getAddress(), // tokenA = WcBTC
+        await jusd.getAddress(), // tokenB = JUSD
+        3000,
+        0,
+        0,
+        wcbtcAmount,
+        jusdAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should handle multiple positions for same user", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount * 3n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount * 3n);
+
+      // Create 3 positions with different tokenIds
+      for (let i = 1; i <= 3; i++) {
+        await positionManager.setMintResult(i, 1000, amount0, amount1);
+        const tx = await gateway
+          .connect(user1)
+          .addLiquidity(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            0,
+            0,
+            jusdAmount,
+            wcbtcAmount,
+            0,
+            0,
+            user1.address,
+            deadline
+          );
+        await expect(tx)
+          .to.emit(gateway, "LiquidityAdded")
+          .withArgs(anyValue, anyValue, anyValue, anyValue, anyValue, i);
+      }
+    });
+  });
+
+  describe("Event Parameter Validation Extended", function () {
+    it("Should emit correct user-facing amounts in SwapExecuted (not actual amounts)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      // Simulate interest accrual to make svJUSD != JUSD
+      await svJusd.accrueInterest(ethers.parseEther("10"));
+
+      const jusdAmount = ethers.parseEther("100");
+      const expectedOutput = ethers.parseEther("1");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await swapRouter.setSwapOutput(expectedOutput);
+
+      await wcbtc.deposit({ value: expectedOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 2n);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      // Event should show JUSD amount (user-facing), not svJUSD amount (actual)
+      await expect(
+        gateway
+          .connect(user1)
+          .swapExactTokensForTokens(
+            await jusd.getAddress(),
+            await wcbtc.getAddress(),
+            3000,
+            jusdAmount,
+            0,
+            user1.address,
+            deadline
+          )
+      )
+        .to.emit(gateway, "SwapExecuted")
+        .withArgs(user1.address, await jusd.getAddress(), await wcbtc.getAddress(), jusdAmount, expectedOutput);
+    });
+
+    it("Should emit LiquidityAdded with correct user-facing amounts", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      // Simulate interest accrual
+      await svJusd.accrueInterest(ethers.parseEther("10"));
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // The event should show user-facing amounts (JUSD), not actual (svJUSD)
+      const tx = await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should return user-facing JUSD amounts from addLiquidity (not svJUSD)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, owner, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      // First deposit to create shares, then accrue interest
+      await jusd.mint(owner.address, ethers.parseEther("100"));
+      await jusd.approve(await svJusd.getAddress(), ethers.parseEther("100"));
+      await svJusd.deposit(ethers.parseEther("100"), owner.address);
+      await svJusd.accrueInterest(ethers.parseEther("10")); // 10% interest
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("110"); // Should convert to ~100 svJUSD shares
+      const wcbtcAmount = ethers.parseEther("1");
+
+      // Calculate expected svJUSD shares
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Call addLiquidity and check return values
+      const result = await gateway
+        .connect(user1)
+        .addLiquidity.staticCall(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          jusdAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      // Return value amountA should be close to jusdAmount (in JUSD), not svJusdShares
+      // With 10% interest: 110 JUSD ≈ 100 svJUSD shares, converting back ≈ 110 JUSD
+      expect(result.amountA).to.be.closeTo(jusdAmount, ethers.parseEther("1"));
+      expect(result.amountB).to.equal(wcbtcAmount);
+    });
+  });
+
+  describe("Unsupported Token Handling", function () {
+    it("Should revert getBridgeStatus for unsupported token", async function () {
+      const { gateway, wcbtc } = await loadFixture(deployGatewayFixture);
+
+      // WcBTC is not a bridged token
+      const status = await gateway.getBridgeStatus(await wcbtc.getAddress());
+
+      expect(status.canMint).to.be.false;
+      expect(status.canBurn).to.be.false;
+      expect(status.mintBlockReason).to.equal("Token not supported");
+      expect(status.burnBlockReason).to.equal("Token not supported");
+    });
+
+    it("Should return false for isBridgedToken with random address", async function () {
+      const { gateway } = await loadFixture(deployGatewayFixture);
+
+      const randomAddress = "0x" + "1".repeat(40);
+      const result = await gateway.isBridgedToken(randomAddress);
+      expect(result).to.be.false;
+    });
+  });
+
+  // ==================== Additional Error Path Tests ====================
+
+  describe("Slippage Protection in increaseLiquidity", function () {
+    it("Should revert with InsufficientOutput when amountA is below minimum", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      // Create initial position
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(amount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await positionManager.connect(user1).setApprovalForAll(await gateway.getAddress(), true);
+
+      // Set increase to return less than minimum
+      const lowAmount = amount / 10n;
+      await positionManager.setIncreaseResult(100, lowAmount, lowAmount);
+
+      // Set high minimum to trigger slippage
+      await expect(
+        gateway.connect(user1).increaseLiquidity(
+          1,
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          amount,
+          amount,
+          amount, // amountAMin = full amount
+          amount, // amountBMin = full amount
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+    });
+  });
+
+  describe("Slippage Protection in addLiquidity", function () {
+    it("Should revert with InsufficientOutput when amountA is below minimum after conversion", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      // Setup: Mock position manager to return amounts that after _toUserAmountForLiquidity
+      // conversion will fall below the user's specified minimum
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Set very low return amounts so that converted amounts fall below minimum
+      const lowAmount = amount / 10n;
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [lowAmount, lowAmount] : [lowAmount, lowAmount];
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      // Call addLiquidity with high minimum that won't be satisfied after conversion
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          amount, // amountAMin = full amount (will fail since PM returns lowAmount)
+          amount, // amountBMin = full amount
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+    });
+
+    it("Should revert with InsufficientOutput when amountB is below minimum after conversion", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Return full amount for token A but low for token B
+      const lowAmount = amount / 10n;
+      const svJusdShares = await svJusd.convertToShares(amount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, lowAmount] : [lowAmount, svJusdShares];
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      // Only set high minimum for amountB
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0, // amountAMin = 0 (don't care)
+          amount, // amountBMin = full amount (will fail)
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+    });
+  });
+
+  describe("Slippage Protection in createPoolAndAddLiquidity", function () {
+    it("Should revert with InsufficientOutput when amountA is below minimum after conversion", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // 1:1 price
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Set very low return amounts so that converted amounts fall below minimum
+      const lowAmount = amount / 10n;
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [lowAmount, lowAmount] : [lowAmount, lowAmount];
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      // Call createPoolAndAddLiquidity with high minimum that won't be satisfied
+      await expect(
+        gateway.connect(user1).createPoolAndAddLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          sqrtPriceX96,
+          0, // full range
+          0,
+          amount,
+          amount,
+          amount, // amountAMin = full amount (will fail)
+          amount, // amountBMin = full amount
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+    });
+
+    it("Should revert with InsufficientOutput when amountB is below minimum after conversion", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336"); // 1:1 price
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+
+      // Return full amount for token A but low for token B
+      const lowAmount = amount / 10n;
+      const svJusdShares = await svJusd.convertToShares(amount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, lowAmount] : [lowAmount, svJusdShares];
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      // Only set high minimum for amountB
+      await expect(
+        gateway.connect(user1).createPoolAndAddLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          sqrtPriceX96,
+          0,
+          0,
+          amount,
+          amount,
+          0, // amountAMin = 0 (don't care)
+          amount, // amountBMin = full amount (will fail)
+          user1.address,
+          deadline
+        )
+      ).to.be.revertedWithCustomError(gateway, "InsufficientOutput");
+    });
+  });
+
+  describe("JUICE Liquidity in increaseLiquidity", function () {
+    it("Should correctly return JUICE amounts when increasing JUICE liquidity", async function () {
+      const { gateway, user1, juice, wcbtc, positionManager } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const juiceAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      // Token ordering: Uniswap V3 requires token0 < token1
+      const juiceAddr = await juice.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const [amount0, amount1] = juiceAddr < wcbtcAddr ? [juiceAmount, wcbtcAmount] : [wcbtcAmount, juiceAmount];
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+
+      await juice.connect(user1).approve(await gateway.getAddress(), juiceAmount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount * 2n);
+
+      // Create initial JUICE/WcBTC position
+      await gateway
+        .connect(user1)
+        .addLiquidity(
+          await juice.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          juiceAmount,
+          wcbtcAmount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      // Approve NFT for gateway
+      await positionManager.connect(user1).setApprovalForAll(await gateway.getAddress(), true);
+
+      // Set position data for the NFT (JUICE/WcBTC pool)
+      await positionManager.setPositionData(
+        1,
+        juiceAddr < wcbtcAddr ? juiceAddr : wcbtcAddr,
+        juiceAddr < wcbtcAddr ? wcbtcAddr : juiceAddr,
+        1000
+      );
+
+      // Set increase result - JUICE amounts should be returned correctly
+      const increaseJuice = ethers.parseEther("50");
+      const increaseWcbtc = ethers.parseEther("0.5");
+      const [incAmount0, incAmount1] =
+        juiceAddr < wcbtcAddr ? [increaseJuice, increaseWcbtc] : [increaseWcbtc, increaseJuice];
+      await positionManager.setIncreaseResult(500, incAmount0, incAmount1);
+
+      // Increase liquidity with JUICE
+      const tx = await gateway
+        .connect(user1)
+        .increaseLiquidity(
+          1,
+          await juice.getAddress(),
+          await wcbtc.getAddress(),
+          juiceAmount,
+          wcbtcAmount,
+          0,
+          0,
+          deadline
+        );
+
+      // Verify event emits correct JUICE amount (not converted)
+      await expect(tx)
+        .to.emit(gateway, "LiquidityIncreased")
+        .withArgs(user1.address, 1, increaseJuice, increaseWcbtc, 500);
+    });
+
+    it("Should revert when increasing liquidity with JUICE paired to USD token", async function () {
+      const { gateway, user1, juice, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const amount = ethers.parseEther("100");
+
+      // First create a valid svJUSD/WcBTC position
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(amount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, amount] : [amount, svJusdShares];
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), amount * 2n);
+
+      await gateway
+        .connect(user1)
+        .addLiquidity(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          3000,
+          0,
+          0,
+          amount,
+          amount,
+          0,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await positionManager.connect(user1).setApprovalForAll(await gateway.getAddress(), true);
+      await juice.connect(user1).approve(await gateway.getAddress(), amount);
+
+      // Try to increase with JUICE + JUSD (invalid pair)
+      await expect(
+        gateway
+          .connect(user1)
+          .increaseLiquidity(1, await juice.getAddress(), await jusd.getAddress(), amount, amount, 0, 0, deadline)
+      ).to.be.revertedWithCustomError(gateway, "JuiceCannotPairWithUsd");
+    });
+  });
+
+  describe("BridgedTokenNotFound Error Paths", function () {
+    it("Should revert bridgedToSvJusd with BridgedTokenNotFound for unregistered token", async function () {
+      const { gateway, wcbtc } = await loadFixture(deployGatewayFixture);
+
+      await expect(
+        gateway.bridgedToSvJusd(await wcbtc.getAddress(), ethers.parseEther("100"))
+      ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+    });
+
+    it("Should revert svJusdToBridged with BridgedTokenNotFound for unregistered token", async function () {
+      const { gateway, wcbtc } = await loadFixture(deployGatewayFixture);
+
+      await expect(
+        gateway.svJusdToBridged(await wcbtc.getAddress(), ethers.parseEther("100"))
+      ).to.be.revertedWithCustomError(gateway, "BridgedTokenNotFound");
+    });
+  });
+
+  describe("Multiple Fee Tier Liquidity Operations", function () {
+    it("Should add liquidity with fee=100 (0.01%) and custom tick range", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Custom tick range aligned to spacing=1
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        100, // 0.01% fee
+        -100, // tickLower (aligned to 1)
+        100, // tickUpper (aligned to 1)
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should add liquidity with fee=500 (0.05%) and custom tick range", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Custom tick range aligned to spacing=10
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        500, // 0.05% fee
+        -1000, // tickLower (aligned to 10)
+        1000, // tickUpper (aligned to 10)
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should add liquidity with fee=10000 (1%) and custom tick range", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Custom tick range aligned to spacing=200
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        10000, // 1% fee
+        -2000, // tickLower (aligned to 200)
+        2000, // tickUpper (aligned to 200)
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+  });
+
+  describe("Native cBTC Error Paths", function () {
+    it("Should revert swap when msg.value doesn't match amount for native input", async function () {
+      const { gateway, user1, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      await expect(
+        gateway.connect(user1).swapExactTokensForTokens(
+          ethers.ZeroAddress, // Native cBTC
+          await wcbtc.getAddress(),
+          3000,
+          ethers.parseEther("1"), // amount
+          0,
+          user1.address,
+          deadline,
+          { value: ethers.parseEther("0.5") } // mismatched value
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidAmount");
+    });
+
+    it("Should revert addLiquidity when msg.value doesn't match native amount", async function () {
+      const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const nativeAmount = ethers.parseEther("1");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+
+      await expect(
+        gateway.connect(user1).addLiquidity(
+          await jusd.getAddress(),
+          ethers.ZeroAddress, // Native cBTC
+          3000,
+          0,
+          0,
+          jusdAmount,
+          nativeAmount,
+          0,
+          0,
+          user1.address,
+          deadline,
+          { value: ethers.parseEther("0.5") } // mismatched value
+        )
+      ).to.be.revertedWithCustomError(gateway, "InvalidAmount");
+    });
+  });
+
+  describe("Swap with All Fee Tiers", function () {
+    it("Should swap with fee=100 (0.01%)", async function () {
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const amount = ethers.parseEther("100");
+      const expectedOutput = ethers.parseEther("1");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await swapRouter.setSwapOutput(expectedOutput);
+      await wcbtc.deposit({ value: expectedOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 2n);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          100,
+          amount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should swap with fee=500 (0.05%)", async function () {
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const amount = ethers.parseEther("100");
+      const expectedOutput = ethers.parseEther("1");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await swapRouter.setSwapOutput(expectedOutput);
+      await wcbtc.deposit({ value: expectedOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 2n);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          500,
+          amount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+
+    it("Should swap with fee=10000 (1%)", async function () {
+      const { gateway, user1, jusd, wcbtc, swapRouter } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const amount = ethers.parseEther("100");
+      const expectedOutput = ethers.parseEther("1");
+
+      await jusd.connect(user1).approve(await gateway.getAddress(), amount);
+      await swapRouter.setSwapOutput(expectedOutput);
+      await wcbtc.deposit({ value: expectedOutput * 2n });
+      await wcbtc.transfer(await swapRouter.getAddress(), expectedOutput * 2n);
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+
+      const tx = await gateway
+        .connect(user1)
+        .swapExactTokensForTokens(
+          await jusd.getAddress(),
+          await wcbtc.getAddress(),
+          10000,
+          amount,
+          0,
+          user1.address,
+          deadline
+        );
+
+      await expect(tx).to.emit(gateway, "SwapExecuted");
+    });
+  });
+
+  describe("View Function Conversions with Interest", function () {
+    it("Should return correct jusdToSvJusd with accrued interest", async function () {
+      const { gateway, svJusd, jusd, owner } = await loadFixture(deployGatewayFixture);
+
+      // First, deposit some JUSD to create shares (100 JUSD = 100 svJUSD at 1:1)
+      await jusd.mint(owner.address, ethers.parseEther("100"));
+      await jusd.approve(await svJusd.getAddress(), ethers.parseEther("100"));
+      await svJusd.deposit(ethers.parseEther("100"), owner.address);
+
+      // Now simulate 10% interest by adding 10 JUSD to assets (110 assets, 100 shares)
+      await svJusd.accrueInterest(ethers.parseEther("10"));
+
+      // With 110 assets and 100 shares, 110 JUSD should give ~100 svJUSD
+      const jusdAmount = ethers.parseEther("110");
+      const svJusdAmount = await gateway.jusdToSvJusd(jusdAmount);
+
+      // 110 JUSD should give ~100 svJUSD with 10% interest
+      expect(svJusdAmount).to.be.closeTo(ethers.parseEther("100"), ethers.parseEther("1"));
+    });
+
+    it("Should return correct svJusdToJusd with accrued interest", async function () {
+      const { gateway, svJusd, jusd, owner } = await loadFixture(deployGatewayFixture);
+
+      // First, deposit some JUSD to create shares (100 JUSD = 100 svJUSD at 1:1)
+      await jusd.mint(owner.address, ethers.parseEther("100"));
+      await jusd.approve(await svJusd.getAddress(), ethers.parseEther("100"));
+      await svJusd.deposit(ethers.parseEther("100"), owner.address);
+
+      // Now simulate 10% interest by adding 10 JUSD to assets (110 assets, 100 shares)
+      await svJusd.accrueInterest(ethers.parseEther("10"));
+
+      // With 110 assets and 100 shares, 100 svJUSD should give ~110 JUSD
+      const svJusdAmount = ethers.parseEther("100");
+      const jusdAmount = await gateway.svJusdToJusd(svJusdAmount);
+
+      // 100 svJUSD should give ~110 JUSD with 10% interest
+      expect(jusdAmount).to.be.closeTo(ethers.parseEther("110"), ethers.parseEther("1"));
+    });
+  });
+
+  describe("createPool Error Paths", function () {
+    it("Should revert createPool with same token pair", async function () {
+      const { gateway, user1, jusd } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+      await expect(
+        gateway.connect(user1).createPool(await jusd.getAddress(), await jusd.getAddress(), 3000, sqrtPriceX96)
+      ).to.be.revertedWithCustomError(gateway, "InvalidTokenPair");
+    });
+
+    it("Should revert createPool with invalid fee", async function () {
+      const { gateway, user1, jusd, wcbtc } = await loadFixture(deployGatewayWithBalancesFixture);
+
+      const sqrtPriceX96 = BigInt("79228162514264337593543950336");
+
+      await expect(
+        gateway.connect(user1).createPool(await jusd.getAddress(), await wcbtc.getAddress(), 1000001, sqrtPriceX96)
+      ).to.be.revertedWithCustomError(gateway, "InvalidFee");
+    });
+  });
+
+  describe("registerBridgedToken Error Paths", function () {
+    it("Should revert when bridge JUSD doesn't match gateway JUSD", async function () {
+      const { gateway, jusd } = await loadFixture(deployGatewayFixture);
+
+      // Deploy a different JUSD
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const fakeJusd = await MockERC20Factory.deploy("Fake JUSD", "FJUSD", 18);
+      const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+
+      // Deploy bridge with different JUSD
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const badBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await fakeJusd.getAddress(), // Wrong JUSD
+        ethers.parseEther("1000000"),
+        52
+      );
+
+      await expect(gateway.registerBridgedToken(await badBridge.getAddress())).to.be.revertedWithCustomError(
+        gateway,
+        "InvalidBridgeConfig"
+      );
+    });
+
+    it("Should revert when bridge is not approved JUSD minter", async function () {
+      const { gateway, jusd } = await loadFixture(deployGatewayFixture);
+
+      // Deploy bridged token
+      const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+      const usdc = await MockERC20Factory.deploy("USD Coin", "USDC", 6);
+
+      // Deploy bridge (NOT registered as minter)
+      const MockBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+      const nonMinterBridge = await MockBridgeFactory.deploy(
+        await usdc.getAddress(),
+        await jusd.getAddress(),
+        ethers.parseEther("1000000"),
+        52
+      );
+
+      // Don't call jusd.setMinter - bridge is not approved
+
+      await expect(gateway.registerBridgedToken(await nonMinterBridge.getAddress())).to.be.revertedWithCustomError(
+        gateway,
+        "BridgeNotApprovedMinter"
+      );
+    });
+  });
+
+  describe("Full Range Tick Calculation", function () {
+    it("Should use correct full range ticks for fee=100 (spacing=1)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Full range (tickLower == tickUpper == 0)
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        100, // fee=100, spacing=1
+        0, // tickLower = tickUpper means full range
+        0,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
+    });
+
+    it("Should use correct full range ticks for fee=10000 (spacing=200)", async function () {
+      const { gateway, user1, jusd, wcbtc, svJusd, positionManager } = await loadFixture(
+        deployGatewayWithBalancesFixture
+      );
+
+      const deadline = (await time.latest()) + DEADLINE_OFFSET;
+      const jusdAmount = ethers.parseEther("100");
+      const wcbtcAmount = ethers.parseEther("1");
+
+      const svJusdAddr = await svJusd.getAddress();
+      const wcbtcAddr = await wcbtc.getAddress();
+      const svJusdShares = await svJusd.convertToShares(jusdAmount);
+      const [amount0, amount1] = svJusdAddr < wcbtcAddr ? [svJusdShares, wcbtcAmount] : [wcbtcAmount, svJusdShares];
+
+      await positionManager.setMintResult(1, 1000, amount0, amount1);
+      await jusd.connect(user1).approve(await gateway.getAddress(), jusdAmount);
+      await wcbtc.connect(user1).approve(await gateway.getAddress(), wcbtcAmount);
+
+      // Full range (tickLower == tickUpper == 0)
+      const tx = await gateway.connect(user1).addLiquidity(
+        await jusd.getAddress(),
+        await wcbtc.getAddress(),
+        10000, // fee=10000, spacing=200
+        0, // tickLower = tickUpper means full range
+        0,
+        jusdAmount,
+        wcbtcAmount,
+        0,
+        0,
+        user1.address,
+        deadline
+      );
+
+      await expect(tx).to.emit(gateway, "LiquidityAdded");
     });
   });
 });


### PR DESCRIPTION
…d USD paths (#24)

* feat: add script to register SUSD as bridged token on Gateway

Add registerSusdBridgedToken.ts script that calls:
  gateway.addBridgedToken(SUSD_ADDRESS, STABLECOIN_BRIDGE_ADDRESS)

This enables SUSD → any token swaps through the Gateway.

After registration, Gateway automatically handles:
- Input: SUSD → bridge.mint() → JUSD → svJUSD
- Output: svJUSD → JUSD → bridge.burnAndSend() → SUSD

Usage:
  npx hardhat run scripts/registerSusdBridgedToken.ts --network citreaTestnet

Requirements:
- DEPLOYER_PRIVATE_KEY must be set in .env
- Signer must be the Gateway owner

The script:
1. Validates all contract addresses from packages
2. Checks if SUSD is already registered
3. Verifies signer is Gateway owner
4. Calls addBridgedToken()
5. Verifies registration and shows bridge status

* fix: remove stopped() from IStablecoinBridge interface

The StablecoinBridge contract from @juicedollar/jusd package does not implement a stopped() function. This was causing an interface mismatch that would make getBridgeStatus() revert when called with a real bridge.

Changes:
- Remove stopped() from IStablecoinBridge interface
- Remove stopped() check from JuiceSwapGateway.getBridgeStatus()
- Remove stopped variable from MockStablecoinBridge
- Remove related tests

* fix: skip swap when actualTokenIn equals actualTokenOut

When both input and output tokens resolve to the same internal token (e.g., JUSD → USDT.e both resolve to svJUSD), no swap is needed. The router would fail trying to swap a token with itself.

This enables bridged stablecoin conversions:
- JUSD → USDT.e (via bridge)
- SUSD → JUSD (via bridge)
- USDT.e → SUSD (via bridge)

* refactor: remove admin functions from JuiceSwapGateway

Remove Ownable/Pausable to align with JuiceSwap's "no admin keys" principle.

Changes:
- Remove Ownable and Pausable inheritance
- Convert defaultFee to immutable constant DEFAULT_FEE (3000)
- Replace addBridgedToken with permissionless registerBridgedToken (secured by JUSD governance via isMinter() check)
- Remove admin functions: setDefaultFee, removeBridgedToken, rescueNative, rescueToken, pause, unpause
- Remove whenNotPaused modifiers from all functions
- Update tests and deployment script accordingly

Security: Bridge registration now relies on JUSD governance approval (suggestMinter → 14+ day veto period) instead of Gateway owner.

* fix: add BridgedTokenRegistered event to interface

* perf: optimize USD conversions by skipping svJUSD roundtrip

Instead of: JUSD → svJUSD → JUSD → Bridge (wastes ~100k gas)
Now:        JUSD → Bridge (direct path)

Affected swaps:
- JUSD ↔ Bridged tokens (USDT.e, USDC.e, etc.)
- Bridged ↔ Bridged tokens
- JUSD/Bridged → JUICE

Adds _isUsdToken() and _handleDirectUsdConversion() helpers. Includes 8 new tests for direct conversion paths.

* docs: update script comment to reflect direct USD path optimization

* feat: enable JUICE as input token via Equity.redeemFrom()

- Add redeemFrom() to IEquity interface to bypass flash loan protection
- Modify _handleTokenIn to use redeemFrom() for JUICE input (user is owner)
- Remove JuiceInputNotSupported error - JUICE input is now supported
- Add JUICE excess handling (returns as JUSD, not JUICE)
- Add redeemFrom() to MockEquity for testing
- Update tests from "JUICE Input Restriction" to "JUICE Input Support"

* fix: add JUICE support to _toActualMinAmount and _toUserAmount

- _toActualMinAmount: Convert JUICE minAmount to svJUSD equivalent (JUICE → JUSD via calculateProceeds → svJUSD)
- _toUserAmount: Convert svJUSD amount back to JUICE equivalent (svJUSD → JUSD → JUICE via calculateShares)

This fixes incorrect slippage protection and event values when JUICE is used as input token for liquidity operations.

Also adds comprehensive JUICE tests:
- Slippage protection (minAmountOut)
- Allowance failure handling
- addLiquidity with JUICE input
- Excess return as JUSD (not JUICE due to flash loan protection)

* Add comprehensive swap matrix tests for all 72 token directions

- Add JuiceSwapGateway.swapMatrix.test.ts with 139 tests covering:
  - All 72 swap directions (9 tokens × 8 targets)
  - Pool swap verification (WcBTC ↔ svJUSD group)
  - Direct conversion verification (USD tokens skip pool)
  - Wrap/unwrap tests (cBTC ↔ WcBTC)
  - svJUSD and JUICE as direct input/output
  - Edge cases for decimal conversion (6 ↔ 18)

- Fix token ordering in existing JUICE liquidity tests:
  - "Should return excess as JUSD when adding liquidity with JUICE"
  - "Should increase liquidity with JUICE as input token" Both tests now correctly sort token0/token1 per Uniswap V3 spec

- Add swapCallCount to MockSwapRouter for pool swap verification

* test: add tests for excess token return in liquidity operations

Add 3 new tests to cover _returnExcess() edge cases:
- Return excess bridged token (USDC) when position manager uses less
- Return excess bridged token (USDT) when increasing liquidity
- Return excess native cBTC when position manager uses less

Improves code coverage from 95.9% to 98.51% statements.

* refactor: remove MAX_BRIDGED_TOKENS limit

The bridge limit was unnecessary because:
- Bridge lookup uses O(1) mapping, not array iteration
- Each bridge requires JUSD governance approval (14+ day veto)
- Spam attacks are impossible due to isMinter() check
- The only array usage is in getBridgedTokens() view function

Removed:
- MAX_BRIDGED_TOKENS constant (was 10)
- TooManyBridgedTokens error
- Limit check in registerBridgedToken()
- Related test case

* simplify registerBridgedToken and remove redundant approval

* restore stopped() bridge check and remove redundant approvals

* feat: add custom tick range support to addLiquidity (#28)

* feat: add custom tick range support to addLiquidity

- Add tickLower and tickUpper parameters to addLiquidity function
- Implement sentinel logic: if tickLower == tickUpper, use full range
- Add _validateTicks helper for custom range validation
- Add InvalidTickRange error for invalid tick configurations
- Update all existing tests to use 0,0 for full-range positions
- Add new tests for custom tick range scenarios

Closes #26

* feat: JUICE stays JUICE for liquidity operations

- JUICE is no longer converted to svJUSD when adding liquidity
- Add JuiceCannotPairWithUsd error for invalid JUICE pairs
- JUICE can only be paired with non-USD tokens (e.g., WcBTC, cBTC)
- Add _handleTokenInForLiquidity for liquidity-specific token handling
- Add _getActualTokenForLiquidity to preserve JUICE identity
- Add _toActualMinAmountForLiquidity for correct min amount calculation
- Update _returnExcess to return JUICE directly (not JUSD)
- Add JUICE approval to PositionManager in constructor
- Update tests for new JUICE liquidity behavior

* fix: removeLiquidity now correctly handles JUICE liquidity pools

- Add _handleTokenOutForLiquidity for JUICE direct transfer
- removeLiquidity now checks position's actual tokens to determine:
  - JUICE liquidity pool: transfer JUICE directly
  - Swap-style pool (svJUSD): convert svJUSD → JUICE via invest
- Add test for removing JUICE liquidity

* feat: add pool creation functions to Gateway

Add createPool() and createPoolAndAddLiquidity() functions that enable users to create new Uniswap V3 pools through the Gateway with automatic token conversion and price adjustment.

New features:
- createPool(): Creates/initializes pool with JUSD→svJUSD price conversion
- createPoolAndAddLiquidity(): Creates pool + adds initial liquidity in one tx
- getPool(): View function to check if pool exists for a token pair

The price conversion automatically adjusts sqrt price based on svJUSD share price when JUSD or bridged tokens are involved.

Includes 16 new tests for pool creation functionality.

* test: extend JuiceSwapGateway test coverage with security and edge case tests

Add ~30 new tests covering:
- Reentrancy protection (malicious ERC20 transfer/transferFrom)
- receive() function validation
- Transfer failure handling
- Token/fee validation edge cases
- Tick spacing alignment per fee tier
- MIN_TICK/MAX_TICK boundary tests
- NFT recovery failure scenarios
- Partial liquidity edge cases
- Sequential operations lifecycle
- Slippage protection boundaries
- Precision and large amount handling

New mock contracts:
- MaliciousERC20.sol: Simulates reentrancy during token transfers
- MaliciousReceiver.sol: Simulates reentrancy via receive() callback
- RejectNative.sol: Tests TransferFailed error handling

Extended MockPositionManager with:
- setFailSafeTransfer() for NFT transfer failure simulation
- burnNFT() for non-existent token tests
- getPositionLiquidity() helper

* refactor: remove duplicate _isConvertibleToSvJusd function

Use existing _isUsdToken instead - both had identical logic.

* test: add extended coverage for createPoolAndAddLiquidity, price math, JUICE and bridge scenarios

Additional ~21 tests covering:
- createPoolAndAddLiquidity: excess returns, same token pair, invalid fee, custom tick ranges, native cBTC, zero price validation
- Price math: high share price conversion, token1 JUSD-based path, small/large sqrt prices
- JUICE edge cases: JUICE to native cBTC, native cBTC to JUICE, slippage protection
- Bridge failures: mint limit exceeded, expired bridge
- View functions: zero amount handling, non-bridged token check
- Sequential operations: full lifecycle add->increase->remove->increase->remove

Total test count: 189 (up from 168)

* test: add final coverage tests for getPool, PM failures, and extreme values

Extended test coverage:
- getPool: JUICE pools, bridged token pools, native cBTC, multiple fee tiers
- Position Manager failures: mint, increaseLiquidity, decreaseLiquidity, createPoolAndAddLiquidity error handling
- Extreme values: 1 wei amounts, max uint128 liquidity, high share prices, precision loss with bridged tokens
- getBridgeStatus: partial capacity, expired bridge status

MockPositionManager extended with:
- setFailNextMint() for mint failure simulation
- setFailNextIncrease() for increaseLiquidity failure simulation
- setFailNextDecrease() for decreaseLiquidity failure simulation

Total test count: 204 (up from 189)

* test: add comprehensive direct USD conversion and edge case tests

Extended test coverage:
- Direct USD conversion paths: JUSD↔JUSD, Bridged→JUSD, Bridged→JUICE, Bridged→Bridged, JUSD→Bridged
- Same token edge cases: svJUSD routing
- Token allowance: exact allowance, multiple sequential swaps
- Liquidity positions: reverse token order, multiple positions per user
- Event validation: user-facing vs actual amounts
- Unsupported token handling: getBridgeStatus, isBridgedToken

Total test count: 218 (up from 204)

* fix: correct view function interest tests by initializing shares first

* fix: use _toUserAmountForLiquidity in increaseLiquidity for correct JUICE handling

- Add _toUserAmountForLiquidity function that keeps JUICE as JUICE
- Update increaseLiquidity to use new function instead of _toUserAmount
- Add tests for increaseLiquidity with JUICE token

* fix: correct return values and add token validation in liquidity functions

- addLiquidity: convert pool amounts to user amounts before returning
- createPoolAndAddLiquidity: same fix as addLiquidity
- removeLiquidity: add token matching validation against position tokens
- Add _toUserAmountForLiquidity function for consistent JUICE handling
- Add tests for TokenMismatch and user amount return values

* remove duplicate constants and redundant allowance check

* enforce slippage protection on user-facing amounts after conversion

---------



---------