### PR TITLE
chore: bump version to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@juicedollar/jusd": "^3.0.0",
     "@juiceswapxyz/launchpad": "^3.0.0",
-    "@juiceswapxyz/sdk-core": "^3.0.1",
+    "@juiceswapxyz/sdk-core": "^3.0.2",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@juicedollar/jusd": "^3.0.0",
     "@juiceswapxyz/launchpad": "^3.0.0",
-    "@juiceswapxyz/sdk-core": "^3.0.0",
+    "@juiceswapxyz/sdk-core": "^3.0.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juiceswap/smart-contracts",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "JuiceSwap Smart Contracts",
   "scripts": {
     "compile": "hardhat compile",
@@ -32,9 +32,9 @@
     "viem": "^2.44.0"
   },
   "devDependencies": {
-    "@juicedollar/jusd": "^1.1.1",
-    "@juiceswapxyz/launchpad": "^2.1.3",
-    "@juiceswapxyz/sdk-core": "^0.1.12-beta.0",
+    "@juicedollar/jusd": "^3.0.0",
+    "@juiceswapxyz/launchpad": "^3.0.0",
+    "@juiceswapxyz/sdk-core": "^3.0.0",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,10 +464,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@juicedollar/jusd@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@juicedollar/jusd/-/jusd-1.1.1.tgz#7f393af1a145bb68e51f03dc8bbf0277d51499b9"
-  integrity sha512-w0xWO7BDLnuPFP8KMjiPgajuBxvCLy7jWqP4zDKKPHN4Miu7iDE0tGsxnw9hUeMT6AQRxTCoCEtNc27JCBva7A==
+"@juicedollar/jusd@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@juicedollar/jusd/-/jusd-3.0.0.tgz#ab5250d3621229316a8bd4dc5a31961443d006e0"
+  integrity sha512-Pg4rhsCZcEiwOYYzs8ZmHluvqPfmYrE/5pLKm5Bfw7BxBFkr4MqX3jolqTh2Ny/oQNUZE+Q++FzF+HpI64zxOw==
   dependencies:
     "@openzeppelin/contracts" "^5.1.0"
     hardhat-abi-exporter "^2.10.0"
@@ -479,21 +479,21 @@
     ts-node "^10.9.1"
     typescript "^5.2.2"
 
-"@juiceswapxyz/launchpad@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@juiceswapxyz/launchpad/-/launchpad-2.1.3.tgz#929d33fbde1e6306c754fb2a29d79d79db832261"
-  integrity sha512-wGqlqervl3M+l7e6a+17l+lmpAwNEoKBUt3YuzJzcbNbOx59GTNSxJDAu17e6S3ptXMCFz+2f3m0Yp6hEUC9JA==
+"@juiceswapxyz/launchpad@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@juiceswapxyz/launchpad/-/launchpad-3.0.0.tgz#21e80b86ea45558de18f1dbc6352089d186c80f5"
+  integrity sha512-4krZ7b7Gzh0hu2BZ0htCmWRYuRAH5mgASdbA3gWtqx8V+XZAtmC1BBDcWKaB3rocRcz6UuVq/2jyAHhAAjwfEw==
   dependencies:
-    "@juicedollar/jusd" "^1.1.1"
-    "@juiceswapxyz/sdk-core" "^0.1.12-beta.0"
+    "@juicedollar/jusd" "^3.0.0"
+    "@juiceswapxyz/sdk-core" "^3.0.0"
     "@openzeppelin/contracts" "^5.4.0"
     "@uniswap/v2-core" "^1.0.1"
     "@uniswap/v2-periphery" "^1.1.0-beta.0"
 
-"@juiceswapxyz/sdk-core@^0.1.12-beta.0":
-  version "0.1.12-beta.0"
-  resolved "https://registry.yarnpkg.com/@juiceswapxyz/sdk-core/-/sdk-core-0.1.12-beta.0.tgz#543557341fe5e29f7b8e227e1222b5fb2b5b1f86"
-  integrity sha512-SZJ4gRzokg7CNkpzPI6MnHF/b4jMezsv3gEnCdAVKaVefqKCLa50jdUHqa361ONYX/3kURXbs3cXfNaCuY1/Cg==
+"@juiceswapxyz/sdk-core@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@juiceswapxyz/sdk-core/-/sdk-core-3.0.0.tgz#78f749eec97c2a41434590dda28869da435ee3e7"
+  integrity sha512-o47LgGC0OdpkEk4Xo9wwhd00B2SbbLNnW9Uls0jb3n9HVJ0240Yj3Esjto5MVIMMA5E602B7FkEcRmL5q9vcVw==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     "@ethersproject/bytes" "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,10 +505,10 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@juiceswapxyz/sdk-core@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@juiceswapxyz/sdk-core/-/sdk-core-3.0.1.tgz#0eafb2b41262dcd39f7ebaf147753dcec5b07e26"
-  integrity sha512-VNv/PLJ0HW3bves5hPBECRgNCJeRGAs1eID1LQIRVaR0FBI9zNk5e9L42zpZA5RA1uhOnI99fgUClnXJrc6YRg==
+"@juiceswapxyz/sdk-core@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@juiceswapxyz/sdk-core/-/sdk-core-3.0.2.tgz#2afd094fa5d1611ffe7ca961129f3f29878b7f01"
+  integrity sha512-rQ/OJszvdba0RQPd//xukNkaygTbb2uQPufVkdJ+75LCHbHUDsgByoBJIiqe/jfhxz5w4oewZtJDceO5xUkwKw==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     "@ethersproject/bytes" "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,6 +505,21 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
+"@juiceswapxyz/sdk-core@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@juiceswapxyz/sdk-core/-/sdk-core-3.0.1.tgz#0eafb2b41262dcd39f7ebaf147753dcec5b07e26"
+  integrity sha512-VNv/PLJ0HW3bves5hPBECRgNCJeRGAs1eID1LQIRVaR0FBI9zNk5e9L42zpZA5RA1uhOnI99fgUClnXJrc6YRg==
+  dependencies:
+    "@ethersproject/address" "^5.0.2"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.4"
+    tiny-invariant "^1.1.0"
+    toformat "^2.0.0"
+
 "@noble/ciphers@^1.3.0":
   version "1.3.0"
   resolved "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz"


### PR DESCRIPTION
## Summary
- Bump package version from 1.0.0 to 3.0.0 for Citrea mainnet release
- Update @juicedollar/jusd dependency to ^3.0.0
- Update @juiceswapxyz/launchpad dependency to ^3.0.0
- Update @juiceswapxyz/sdk-core dependency to ^3.0.0

## Test plan
- [ ] Verify package.json version is correct
- [ ] Run build to ensure no breaking changes