### PR TITLE
Update Citrea block explorer URL to citreascan.com

### DIFF
--- a/scripts/utils/deploy-helpers.ts
+++ b/scripts/utils/deploy-helpers.ts
@@ -67,7 +67,7 @@ export const NETWORK_CONFIGS: Record<string, NetworkConfig> = {
   citrea: {
     name: "Citrea Mainnet",
     folder: "mainnet",
-    explorerUrl: "https://explorer.citrea.xyz",
+    explorerUrl: "https://citreascan.com",
     isLocal: false,
   },
 };


### PR DESCRIPTION
## Summary
- Update Citrea block explorer URL from `explorer.citrea.xyz` to `citreascan.com`

## Test plan
- [ ] Verify deployment scripts show correct explorer links