### PR TITLE
Update Citrea RPC and explorer URLs to citreascan.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 # ========================================
 
 # Citrea RPC URLs
-CITREA_TESTNET_RPC=https://rpc.testnet.citrea.xyz
-CITREA_MAINNET_RPC=https://rpc.mainnet.citrea.xyz
+CITREA_TESTNET_RPC=https://rpc.testnet.citreascan.com
+CITREA_MAINNET_RPC=https://rpc.citreascan.com
 
 # Private key of deployer wallet (must have cBTC for gas)
 # IMPORTANT: Never commit this key to git!
@@ -44,7 +44,7 @@ TRANSFER_OWNERSHIP=false
 #     npm run node:fork:mainnet
 #
 #   For Governance integration tests (requires Anvil):
-#     anvil --fork-url https://rpc.testnet.citrea.xyz --chain-id 5115
+#     anvil --fork-url https://rpc.testnet.citreascan.com --chain-id 5115
 #     npm run test:gov:anvil
 
 # ========================================

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,7 +37,7 @@ Edit `.env` and add:
 
 ```env
 # Deployment Configuration
-CITREA_RPC_URL=https://rpc.testnet.citrea.xyz
+CITREA_RPC_URL=https://rpc.testnet.citreascan.com
 DEPLOYER_PRIVATE_KEY=your_private_key_here
 
 # JuiceDollar Protocol Addresses
@@ -161,4 +161,4 @@ The JuiceSwapGateway acts as an abstraction layer that:
 
 For issues or questions:
 - GitHub: https://github.com/JuiceSwapxyz
-- Explorer: https://explorer.testnet.citrea.xyz
+- Explorer: https://testnet.citreascan.com

--- a/DEPLOYMENT_CITREA_TESTNET.md
+++ b/DEPLOYMENT_CITREA_TESTNET.md
@@ -14,7 +14,7 @@
 ### JuiceSwapGateway
 **Address:** `0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C`
 
-**Explorer:** https://explorer.testnet.citrea.xyz/address/0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C
+**Explorer:** https://testnet.citreascan.com/address/0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C
 
 **Configuration:**
 - Default Fee: 3000 (0.3%)
@@ -39,7 +39,7 @@
 ## 🧪 Testing the Contract
 
 ### 1. View on Explorer
-Visit: https://explorer.testnet.citrea.xyz/address/0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C
+Visit: https://testnet.citreascan.com/address/0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C
 
 ### 2. Read Functions (No gas needed)
 
@@ -181,7 +181,7 @@ The contract is fully deployed and functional at `0x79EC249234F7f37C1Dec87513774
 
 **View the contract:**
 - Dev Explorer: https://dev.testnet.citreascan.com/address/0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C
-- Main Explorer: https://explorer.testnet.citrea.xyz/address/0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C
+- Main Explorer: https://testnet.citreascan.com/address/0x79EC249234F7f37C1Dec87513774A9E3C3EDFd8C
 
 **Verification details:**
 - Compiler: v0.8.20+commit.a1b79de6
@@ -227,7 +227,7 @@ The contract is fully deployed and functional at `0x79EC249234F7f37C1Dec87513774
 ## 📞 Support
 
 **Contract Issues:** Create issue in GitHub repo
-**Explorer:** https://explorer.testnet.citrea.xyz
+**Explorer:** https://testnet.citreascan.com
 **Documentation:** See README.md and test files
 
 ---

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ FORK_TESTNET=true npm test
 
 **Citrea Testnet:**
 - Chain ID: 5115
-- RPC: https://rpc.testnet.citrea.xyz
+- RPC: https://rpc.testnet.citreascan.com
 - Native Token: cBTC (testnet Bitcoin)
 
 ## License

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -54,8 +54,8 @@ const config: HardhatUserConfig = {
         network: "citrea",
         chainId: 4114,
         urls: {
-          apiURL: "https://explorer.mainnet.citrea.xyz/api",
-          browserURL: "https://explorer.mainnet.citrea.xyz",
+          apiURL: "https://citreascan.com/api",
+          browserURL: "https://citreascan.com",
         },
       },
     ],
@@ -71,10 +71,10 @@ const config: HardhatUserConfig = {
         ? [{ privateKey: process.env.DEPLOYER_PRIVATE_KEY, balance: "10000000000000000000" }]
         : undefined,
       forking: process.env.FORK_TESTNET ? {
-        url: process.env.CITREA_TESTNET_RPC || "https://rpc.testnet.citrea.xyz",
+        url: process.env.CITREA_TESTNET_RPC || "https://rpc.testnet.citreascan.com",
         enabled: true,
       } : process.env.FORK_MAINNET ? {
-        url: process.env.CITREA_MAINNET_RPC || "https://rpc.mainnet.citrea.xyz",
+        url: process.env.CITREA_MAINNET_RPC || "https://rpc.citreascan.com",
         enabled: true,
       } : undefined,
       chains: {
@@ -101,14 +101,14 @@ const config: HardhatUserConfig = {
       timeout: 300_000,
     },
     // Anvil fork networks - use when Hardhat's built-in forking fails (e.g., Governance tests)
-    // Start Anvil first: anvil --fork-url https://rpc.testnet.citrea.xyz --chain-id 5115
+    // Start Anvil first: anvil --fork-url https://rpc.testnet.citreascan.com --chain-id 5115
     anvilTestnet: {
       url: "http://127.0.0.1:8545",
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
       chainId: 5115,
       timeout: 300_000,
     },
-    // Start Anvil first: anvil --fork-url https://rpc.mainnet.citrea.xyz --chain-id 4114
+    // Start Anvil first: anvil --fork-url https://rpc.citreascan.com --chain-id 4114
     anvilMainnet: {
       url: "http://127.0.0.1:8545",
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
@@ -116,13 +116,13 @@ const config: HardhatUserConfig = {
       timeout: 300_000,
     },
     citreaTestnet: {
-      url: process.env.CITREA_TESTNET_RPC || "https://rpc.testnet.citrea.xyz",
+      url: process.env.CITREA_TESTNET_RPC || "https://rpc.testnet.citreascan.com",
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
       chainId: 5115,
       timeout: 300_000,
     },
     citrea: {
-      url: process.env.CITREA_MAINNET_RPC || "https://rpc.mainnet.citrea.xyz",
+      url: process.env.CITREA_MAINNET_RPC || "https://rpc.citreascan.com",
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
       chainId: 4114,
       timeout: 300_000,

--- a/scripts/utils/deploy-helpers.ts
+++ b/scripts/utils/deploy-helpers.ts
@@ -61,7 +61,7 @@ export const NETWORK_CONFIGS: Record<string, NetworkConfig> = {
   citreaTestnet: {
     name: "Citrea Testnet",
     folder: "testnet",
-    explorerUrl: "https://explorer.testnet.citrea.xyz",
+    explorerUrl: "https://testnet.citreascan.com",
     isLocal: false,
   },
   citrea: {

--- a/test/Governance.integration.ts
+++ b/test/Governance.integration.ts
@@ -16,7 +16,7 @@ import { ADDRESS as LAUNCHPAD_ADDRESS } from "@juiceswapxyz/launchpad";
  * Governance Integration Tests - Citrea Testnet
  *
  * Run with Anvil fork (recommended):
- *   1. anvil --fork-url https://rpc.testnet.citrea.xyz --chain-id 5115
+ *   1. anvil --fork-url https://rpc.testnet.citreascan.com --chain-id 5115
  *   2. DEPLOYER_PRIVATE_KEY=0x... npx hardhat test test/Governance.integration.ts --network anvilTestnet
  *
  * Or with Hardhat fork:


### PR DESCRIPTION
## Summary
- Update RPC URLs from citrea.xyz to citreascan.com
- Update explorer URLs to new citreascan.com domain

## Changes
| Old URL | New URL |
|---------|---------|
| `https://rpc.citrea.xyz` | `https://rpc.citreascan.com` |
| `https://rpc.testnet.citrea.xyz` | `https://rpc.testnet.citreascan.com` |
| `https://explorer.mainnet.citrea.xyz` | `https://citreascan.com` |
| `https://explorer.testnet.citrea.xyz` | `https://testnet.citreascan.com` |

## Test plan
- [ ] Verify RPC connections work with new URLs
- [ ] Verify explorer links resolve correctly