### PR TITLE
feat(nft): JuicerNFT loyalty drop contract + tests

### DIFF
--- a/contracts/nft/JUICER_NFT_STATUS.md
+++ b/contracts/nft/JUICER_NFT_STATUS.md
@@ -1,0 +1,28 @@
+# JuicerNFT — status
+
+The points-reward NFT for the Juice Points program, modeled on
+[`FirstSqueezerNFT.sol`](./FirstSqueezerNFT.sol): signature-based `claim(bytes)`
+verified by the backend signer, one mint per address, a campaign window and a
+hard max-supply cap. Owner can rotate the signer.
+
+## State
+
+- **Contract:** `contracts/nft/JuicerNFT.sol` — complete.
+- **Tests:** `test/JuicerNFT.test.ts` — 48 passing (`npx hardhat test test/JuicerNFT.test.ts`).
+- **Deploy script:** `scripts/deployJuicerNFT.ts` — parameterized via env.
+- **Deployed:** **NO.** Intentionally not deployed yet (see below).
+
+## ⚠️ Before any deployment
+
+1. **Artwork / metadata — must be different from the First Squeezer NFT.**
+   The token image + metadata are supplied at deploy time via
+   `JUICER_BASE_TOKEN_URI` (IPFS), not baked into the contract. The final
+   Juicer artwork is **still a placeholder / TODO** — pin the new image +
+   metadata to IPFS and set `JUICER_BASE_TOKEN_URI` to that CID before deploying.
+2. The on-chain `signer` must equal the api's `JUICER_SIGNER_PRIVATE_KEY` address,
+   or every `claim()` reverts with `InvalidSignature`.
+3. The frontend keeps the Juicer NFT surfaces hidden behind `JUICE_POINTS_NFT`
+   (bapp) until the NFT is explicitly unlocked — people collect points first.
+
+Do **not** run `scripts/deployJuicerNFT.ts` until the artwork is finalized and a
+deploy is explicitly authorized.

--- a/contracts/nft/JuicerNFT.sol
+++ b/contracts/nft/JuicerNFT.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+/**
+ * @title JuicerNFT
+ * @notice Campaign NFT for active JuiceSwap users (post-launch loyalty drop).
+ * @dev Signature-based claiming verified by the backend API; structurally
+ *      identical to `FirstSqueezerNFT`, only the eligibility rules enforced
+ *      off-chain by the signer differ.
+ *
+ * Eligibility (enforced server-side; the contract trusts the backend signer):
+ *  - >= 10 confirmed JuiceSwap swaps from this address
+ *  - >= $5 active deposit in JUSD savings
+ *  - >= $5 active lending position denominated in JUSD
+ *
+ * Features:
+ *  - One mint per address (enforced by `hasClaimed` mapping)
+ *  - Campaign window bounded by immutable start/end timestamps
+ *  - Signature verification by trusted backend signer
+ *  - Static metadata URI (IPFS) shared by all minted tokens
+ */
+contract JuicerNFT is ERC721 {
+    using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;
+
+    /// @notice Campaign start timestamp
+    uint256 public immutable CAMPAIGN_START;
+
+    /// @notice Campaign end timestamp
+    uint256 public immutable CAMPAIGN_END;
+
+    /// @notice Backend API signer address (verifies eligibility)
+    address public immutable signer;
+
+    /// @notice Base URI for token metadata (IPFS)
+    string private _baseTokenURI;
+
+    /// @notice Track claimed addresses (one NFT per address)
+    mapping(address => bool) public hasClaimed;
+
+    /// @notice Current token ID counter
+    uint256 private _tokenIdCounter;
+
+    /// @notice Emitted when an NFT is successfully claimed
+    event NFTClaimed(address indexed claimer, uint256 indexed tokenId);
+
+    /// @notice Campaign has not started yet
+    error CampaignNotStarted();
+
+    /// @notice Campaign has ended
+    error CampaignEnded();
+
+    /// @notice Address has already claimed
+    error AlreadyClaimed();
+
+    /// @notice Invalid signature from backend
+    error InvalidSignature();
+
+    /**
+     * @notice Initialize the Juicer NFT contract
+     * @param _signer Backend API signer address
+     * @param baseTokenURI IPFS base URI for metadata
+     * @param _campaignStart Campaign start timestamp
+     * @param _campaignEnd Campaign end timestamp
+     */
+    constructor(
+        address _signer,
+        string memory baseTokenURI,
+        uint256 _campaignStart,
+        uint256 _campaignEnd
+    ) ERC721("Juicer", "JUICER") {
+        require(_signer != address(0), "Invalid signer address");
+        require(_campaignStart < _campaignEnd, "Invalid campaign period");
+        require(_campaignEnd > block.timestamp, "Campaign already ended");
+
+        signer = _signer;
+        _baseTokenURI = baseTokenURI;
+        CAMPAIGN_START = _campaignStart;
+        CAMPAIGN_END = _campaignEnd;
+    }
+
+    /**
+     * @notice Claim Juicer NFT
+     * @dev Requires valid signature from backend API confirming all eligibility conditions
+     *      (>=10 swaps, >=$5 JUSD savings, >=$5 JUSD lending).
+     * @param signature Backend signature proving the user satisfies the conditions
+     */
+    function claim(bytes memory signature) external {
+        // Check campaign has started
+        if (block.timestamp < CAMPAIGN_START) revert CampaignNotStarted();
+
+        // Check campaign deadline
+        if (block.timestamp > CAMPAIGN_END) revert CampaignEnded();
+
+        // Check if already claimed
+        if (hasClaimed[msg.sender]) revert AlreadyClaimed();
+
+        // Verify signature from backend API
+        bytes32 messageHash = keccak256(abi.encodePacked(address(this), block.chainid, msg.sender));
+        bytes32 ethSignedHash = messageHash.toEthSignedMessageHash();
+        address recovered = ethSignedHash.recover(signature);
+
+        if (recovered != signer) revert InvalidSignature();
+
+        // Mark as claimed
+        hasClaimed[msg.sender] = true;
+
+        // Increment token ID and mint
+        _tokenIdCounter++;
+        _safeMint(msg.sender, _tokenIdCounter);
+
+        emit NFTClaimed(msg.sender, _tokenIdCounter);
+    }
+
+    /**
+     * @notice Get token URI for a specific token
+     * @dev All tokens share the same static metadata URI
+     * @param tokenId Token ID to query
+     * @return Token metadata URI
+     */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        _requireOwned(tokenId);
+        return _baseTokenURI;
+    }
+
+    /**
+     * @notice Get total number of NFTs minted
+     * @return Total supply
+     */
+    function totalSupply() external view returns (uint256) {
+        return _tokenIdCounter;
+    }
+
+    /**
+     * @notice Base URI for computing tokenURI
+     * @return Base URI string
+     */
+    function _baseURI() internal view override returns (string memory) {
+        return _baseTokenURI;
+    }
+}

--- a/contracts/nft/JuicerNFT.sol
+++ b/contracts/nft/JuicerNFT.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title JuicerNFT
@@ -23,7 +24,7 @@ import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
  *  - Signature verification by trusted backend signer
  *  - Static metadata URI (IPFS) shared by all minted tokens
  */
-contract JuicerNFT is ERC721 {
+contract JuicerNFT is ERC721, Ownable {
     using ECDSA for bytes32;
     using MessageHashUtils for bytes32;
 
@@ -33,8 +34,11 @@ contract JuicerNFT is ERC721 {
     /// @notice Campaign end timestamp
     uint256 public immutable CAMPAIGN_END;
 
-    /// @notice Backend API signer address (verifies eligibility)
-    address public immutable signer;
+    /// @notice Backend API signer address (verifies eligibility); rotatable by the owner
+    address public signer;
+
+    /// @notice Hard cap on the total number of mintable NFTs
+    uint256 public immutable maxSupply;
 
     /// @notice Base URI for token metadata (IPFS)
     string private _baseTokenURI;
@@ -48,6 +52,9 @@ contract JuicerNFT is ERC721 {
     /// @notice Emitted when an NFT is successfully claimed
     event NFTClaimed(address indexed claimer, uint256 indexed tokenId);
 
+    /// @notice Emitted when the backend signer is rotated by the owner
+    event SignerUpdated(address indexed oldSigner, address indexed newSigner);
+
     /// @notice Campaign has not started yet
     error CampaignNotStarted();
 
@@ -60,6 +67,9 @@ contract JuicerNFT is ERC721 {
     /// @notice Invalid signature from backend
     error InvalidSignature();
 
+    /// @notice The max-supply cap has been reached
+    error MaxSupplyReached();
+
     /**
      * @notice Initialize the Juicer NFT contract
      * @param _signer Backend API signer address
@@ -71,13 +81,16 @@ contract JuicerNFT is ERC721 {
         address _signer,
         string memory baseTokenURI,
         uint256 _campaignStart,
-        uint256 _campaignEnd
-    ) ERC721("Juicer", "JUICER") {
+        uint256 _campaignEnd,
+        uint256 _maxSupply
+    ) ERC721("Juicer", "JUICER") Ownable(msg.sender) {
         require(_signer != address(0), "Invalid signer address");
         require(_campaignStart < _campaignEnd, "Invalid campaign period");
         require(_campaignEnd > block.timestamp, "Campaign already ended");
+        require(_maxSupply > 0, "Invalid max supply");
 
         signer = _signer;
+        maxSupply = _maxSupply;
         _baseTokenURI = baseTokenURI;
         CAMPAIGN_START = _campaignStart;
         CAMPAIGN_END = _campaignEnd;
@@ -106,6 +119,9 @@ contract JuicerNFT is ERC721 {
 
         if (recovered != signer) revert InvalidSignature();
 
+        // Enforce the hard supply cap
+        if (_tokenIdCounter >= maxSupply) revert MaxSupplyReached();
+
         // Mark as claimed
         hasClaimed[msg.sender] = true;
 
@@ -114,6 +130,17 @@ contract JuicerNFT is ERC721 {
         _safeMint(msg.sender, _tokenIdCounter);
 
         emit NFTClaimed(msg.sender, _tokenIdCounter);
+    }
+
+    /**
+     * @notice Rotate the backend signer (e.g. after a key compromise)
+     * @param newSigner New backend signer address
+     */
+    function setSigner(address newSigner) external onlyOwner {
+        require(newSigner != address(0), "Invalid signer address");
+        address oldSigner = signer;
+        signer = newSigner;
+        emit SignerUpdated(oldSigner, newSigner);
     }
 
     /**

--- a/scripts/deployJuicerNFT.ts
+++ b/scripts/deployJuicerNFT.ts
@@ -1,0 +1,137 @@
+import { ethers, network, run } from "hardhat";
+import "dotenv/config";
+
+/**
+ * Deploy JuicerNFT.sol — the signature-claimed Juicer loyalty NFT.
+ *
+ * All product parameters come from env so a deployment needs no code change:
+ *
+ *   JUICER_SIGNER_ADDRESS   (required) — backend signer. MUST equal the
+ *                           address of JUICER_SIGNER_PRIVATE_KEY in the api
+ *                           repo, or every claim() reverts with InvalidSignature.
+ *   JUICER_BASE_TOKEN_URI   (required) — IPFS base URI for metadata
+ *                           (e.g. "ipfs://<CID>/").
+ *   JUICER_CAMPAIGN_START   (optional) — unix seconds; default = now.
+ *   JUICER_CAMPAIGN_END     (required) — unix seconds; must be > start and now.
+ *   JUICER_MAX_SUPPLY       (required) — hard cap, > 0.
+ *   DEPLOYER_PRIVATE_KEY    (required for live networks) — funded deployer.
+ *
+ * Usage:
+ *   npx hardhat run scripts/deployJuicerNFT.ts --network citreaTestnet
+ *   npx hardhat run scripts/deployJuicerNFT.ts --network citrea
+ *
+ * After deploy, wire the printed address into:
+ *   - api  .env: JUICER_NFT_CONTRACT_MAINNET / _TESTNET
+ *   - bapp juicerCampaign service contract constant
+ * and confirm the on-chain `signer` matches the api signer (printed below).
+ */
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.trim() === "") {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return v.trim();
+}
+
+function optionalIntEnv(name: string, fallback: number): number {
+  const v = process.env[name];
+  if (!v || v.trim() === "") return fallback;
+  const n = Number(v);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`${name} must be a non-negative integer (got "${v}")`);
+  }
+  return n;
+}
+
+async function main(): Promise<void> {
+  const signerAddress = requireEnv("JUICER_SIGNER_ADDRESS");
+  if (!ethers.isAddress(signerAddress)) {
+    throw new Error(`JUICER_SIGNER_ADDRESS is not a valid address: ${signerAddress}`);
+  }
+  const baseTokenURI = requireEnv("JUICER_BASE_TOKEN_URI");
+  const nowSec = Math.floor(Date.now() / 1000);
+  const campaignStart = optionalIntEnv("JUICER_CAMPAIGN_START", nowSec);
+  const campaignEnd = Number(requireEnv("JUICER_CAMPAIGN_END"));
+  const maxSupply = Number(requireEnv("JUICER_MAX_SUPPLY"));
+
+  // Mirror the constructor's require() checks so misconfig fails locally,
+  // before spending gas on a guaranteed revert.
+  if (!Number.isInteger(campaignEnd) || campaignEnd <= campaignStart) {
+    throw new Error("JUICER_CAMPAIGN_END must be an integer greater than the start");
+  }
+  if (campaignEnd <= nowSec) {
+    throw new Error("JUICER_CAMPAIGN_END must be in the future");
+  }
+  if (!Number.isInteger(maxSupply) || maxSupply <= 0) {
+    throw new Error("JUICER_MAX_SUPPLY must be a positive integer");
+  }
+
+  const [deployer] = await ethers.getSigners();
+  const balance = await ethers.provider.getBalance(deployer.address);
+
+  console.log("=== JuicerNFT deployment ===");
+  console.log("Network:        ", network.name);
+  console.log("Deployer:       ", deployer.address);
+  console.log("Deployer balance:", ethers.formatEther(balance), "cBTC");
+  console.log("Signer:         ", signerAddress);
+  console.log("Base token URI: ", baseTokenURI);
+  console.log("Campaign start: ", campaignStart, `(${new Date(campaignStart * 1000).toISOString()})`);
+  console.log("Campaign end:   ", campaignEnd, `(${new Date(campaignEnd * 1000).toISOString()})`);
+  console.log("Max supply:     ", maxSupply);
+
+  const JuicerNFT = await ethers.getContractFactory("JuicerNFT");
+  const contract = await JuicerNFT.deploy(
+    signerAddress,
+    baseTokenURI,
+    campaignStart,
+    campaignEnd,
+    maxSupply,
+  );
+  await contract.waitForDeployment();
+
+  const deployedAddress = await contract.getAddress();
+  console.log("\n✅ JuicerNFT deployed at:", deployedAddress);
+
+  // Sanity: read back the configured signer so the operator can confirm it
+  // matches the api signer before any user tries to claim. (`signer` collides
+  // with ethers' Contract.signer property, so go through `functions`.)
+  const onChainSigner: string = await contract.getFunction("signer")();
+  console.log("On-chain signer:", onChainSigner);
+  if (onChainSigner.toLowerCase() !== signerAddress.toLowerCase()) {
+    console.warn("⚠️  On-chain signer does not match JUICER_SIGNER_ADDRESS!");
+  }
+
+  console.log("\nNext steps:");
+  console.log(
+    `  api  .env -> JUICER_NFT_CONTRACT_${network.name === "citreaTestnet" ? "TESTNET" : "MAINNET"}=${deployedAddress}`,
+  );
+  console.log("  bapp -> set the JuicerNFT contract address in the juicerCampaign service");
+  console.log("  api  -> JUICER_SIGNER_PRIVATE_KEY must be the key for", signerAddress);
+
+  // Best-effort verification on live networks.
+  if (network.name === "citrea" || network.name === "citreaTestnet") {
+    console.log("\nWaiting for confirmations before verification...");
+    await contract.deploymentTransaction()?.wait(5);
+    try {
+      await run("verify:verify", {
+        address: deployedAddress,
+        constructorArguments: [
+          signerAddress,
+          baseTokenURI,
+          campaignStart,
+          campaignEnd,
+          maxSupply,
+        ],
+      });
+      console.log("✅ Verified on block explorer");
+    } catch (err: any) {
+      console.warn("Verification skipped/failed:", err.message);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/JuicerNFT.test.ts
+++ b/test/JuicerNFT.test.ts
@@ -22,8 +22,10 @@ describe("JuicerNFT", function () {
     return signature;
   }
 
+  const MAX_SUPPLY = 10_000;
+
   async function deployNFTFixture() {
-    const [, signer, user1, user2, attacker] = await ethers.getSigners();
+    const [owner, signer, user1, user2, attacker, newSigner] = await ethers.getSigners();
 
     // Use dynamic timestamps relative to current block time
     const currentTime = await time.latest();
@@ -35,11 +37,12 @@ describe("JuicerNFT", function () {
       signer.address,
       METADATA_URI,
       CAMPAIGN_START,
-      CAMPAIGN_END
+      CAMPAIGN_END,
+      MAX_SUPPLY
     )) as unknown as JuicerNFT;
     await nft.waitForDeployment();
 
-    return { nft, signer, user1, user2, attacker, CAMPAIGN_START, CAMPAIGN_END };
+    return { nft, owner, signer, user1, user2, attacker, newSigner, CAMPAIGN_START, CAMPAIGN_END };
   }
 
   async function deployNFTDuringCampaignFixture() {
@@ -83,7 +86,8 @@ describe("JuicerNFT", function () {
           ethers.ZeroAddress,
           METADATA_URI,
           currentTime + 3600,
-          currentTime + 7 * 24 * 3600
+          currentTime + 7 * 24 * 3600,
+          MAX_SUPPLY
         )
       ).to.be.revertedWith("Invalid signer address");
     });
@@ -408,4 +412,91 @@ describe("JuicerNFT", function () {
         .to.be.revertedWithCustomError(nft, "CampaignEnded");
     });
   });
+
+  describe("Signer Rotation", function () {
+    it("Should set owner to the deployer", async function () {
+      const { nft, owner } = await loadFixture(deployNFTFixture);
+      expect(await nft.owner()).to.equal(owner.address);
+    });
+
+    it("Should let the owner rotate the signer and emit SignerUpdated", async function () {
+      const { nft, owner, signer, newSigner } = await loadFixture(deployNFTFixture);
+      await expect(nft.connect(owner).setSigner(newSigner.address))
+        .to.emit(nft, "SignerUpdated")
+        .withArgs(signer.address, newSigner.address);
+      expect(await nft.signer()).to.equal(newSigner.address);
+    });
+
+    it("Should reject claims signed by the old signer after rotation", async function () {
+      const { nft, owner, signer, newSigner, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      await nft.connect(owner).setSigner(newSigner.address);
+      const staleSig = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await expect(nft.connect(user1).claim(staleSig)).to.be.revertedWithCustomError(nft, "InvalidSignature");
+    });
+
+    it("Should accept claims signed by the new signer after rotation", async function () {
+      const { nft, owner, newSigner, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      await nft.connect(owner).setSigner(newSigner.address);
+      const sig = await generateSignature(await nft.getAddress(), user1.address, newSigner);
+      await expect(nft.connect(user1).claim(sig)).to.emit(nft, "NFTClaimed");
+      expect(await nft.ownerOf(1)).to.equal(user1.address);
+    });
+
+    it("Should revert setSigner from a non-owner", async function () {
+      const { nft, attacker, newSigner } = await loadFixture(deployNFTFixture);
+      await expect(nft.connect(attacker).setSigner(newSigner.address))
+        .to.be.revertedWithCustomError(nft, "OwnableUnauthorizedAccount")
+        .withArgs(attacker.address);
+    });
+
+    it("Should revert setSigner to the zero address", async function () {
+      const { nft, owner } = await loadFixture(deployNFTFixture);
+      await expect(nft.connect(owner).setSigner(ethers.ZeroAddress)).to.be.revertedWith("Invalid signer address");
+    });
+  });
+
+  describe("Max Supply Cap", function () {
+    async function deployLowCapFixture() {
+      const [owner, signer, user1, user2, user3] = await ethers.getSigners();
+      const currentTime = await time.latest();
+      const CAMPAIGN_START = currentTime + 3600;
+      const CAMPAIGN_END = currentTime + 7 * 24 * 3600;
+      const JuicerNFT = await ethers.getContractFactory("JuicerNFT");
+      const nft = (await JuicerNFT.deploy(
+        signer.address,
+        METADATA_URI,
+        CAMPAIGN_START,
+        CAMPAIGN_END,
+        2
+      )) as unknown as JuicerNFT;
+      await nft.waitForDeployment();
+      await time.increaseTo(CAMPAIGN_START + 1000);
+      return { nft, signer, user1, user2, user3 };
+    }
+
+    it("Should expose the configured maxSupply", async function () {
+      const { nft } = await loadFixture(deployLowCapFixture);
+      expect(await nft.maxSupply()).to.equal(2);
+    });
+
+    it("Should allow maxSupply claims then revert the next valid claim", async function () {
+      const { nft, signer, user1, user2, user3 } = await loadFixture(deployLowCapFixture);
+      const addr = await nft.getAddress();
+      await nft.connect(user1).claim(await generateSignature(addr, user1.address, signer));
+      await nft.connect(user2).claim(await generateSignature(addr, user2.address, signer));
+      const validThird = await generateSignature(addr, user3.address, signer);
+      await expect(nft.connect(user3).claim(validThird)).to.be.revertedWithCustomError(nft, "MaxSupplyReached");
+      expect(await nft.totalSupply()).to.equal(2);
+    });
+
+    it("Should reject deployment with a zero maxSupply", async function () {
+      const [, signer] = await ethers.getSigners();
+      const currentTime = await time.latest();
+      const JuicerNFT = await ethers.getContractFactory("JuicerNFT");
+      await expect(
+        JuicerNFT.deploy(signer.address, METADATA_URI, currentTime + 3600, currentTime + 7 * 24 * 3600, 0)
+      ).to.be.revertedWith("Invalid max supply");
+    });
+  });
+
 });

--- a/test/JuicerNFT.test.ts
+++ b/test/JuicerNFT.test.ts
@@ -1,0 +1,411 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { JuicerNFT } from "../typechain-types";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("JuicerNFT", function () {
+  const METADATA_URI = "ipfs://QmTest123456789";
+
+  async function generateSignature(
+    contractAddress: string,
+    claimer: string,
+    signerWallet: HardhatEthersSigner
+  ): Promise<string> {
+    const network = await ethers.provider.getNetwork();
+    const chainId = network.chainId;
+    const messageHash = ethers.solidityPackedKeccak256(
+      ["address", "uint256", "address"],
+      [contractAddress, chainId, claimer]
+    );
+    const signature = await signerWallet.signMessage(ethers.getBytes(messageHash));
+    return signature;
+  }
+
+  async function deployNFTFixture() {
+    const [, signer, user1, user2, attacker] = await ethers.getSigners();
+
+    // Use dynamic timestamps relative to current block time
+    const currentTime = await time.latest();
+    const CAMPAIGN_START = currentTime + 3600; // Start in 1 hour
+    const CAMPAIGN_END = currentTime + 7 * 24 * 3600; // End in 7 days
+
+    const JuicerNFT = await ethers.getContractFactory("JuicerNFT");
+    const nft = (await JuicerNFT.deploy(
+      signer.address,
+      METADATA_URI,
+      CAMPAIGN_START,
+      CAMPAIGN_END
+    )) as unknown as JuicerNFT;
+    await nft.waitForDeployment();
+
+    return { nft, signer, user1, user2, attacker, CAMPAIGN_START, CAMPAIGN_END };
+  }
+
+  async function deployNFTDuringCampaignFixture() {
+    const fixture = await deployNFTFixture();
+    await time.increaseTo(fixture.CAMPAIGN_START + 1000);
+    return fixture;
+  }
+
+  describe("Deployment", function () {
+    it("Should set the correct name and symbol", async function () {
+      const { nft } = await loadFixture(deployNFTFixture);
+      expect(await nft.name()).to.equal("Juicer");
+      expect(await nft.symbol()).to.equal("JUICER");
+    });
+
+    it("Should set the correct signer address", async function () {
+      const { nft, signer } = await loadFixture(deployNFTFixture);
+      expect(await nft.signer()).to.equal(signer.address);
+    });
+
+    it("Should set the correct campaign start timestamp", async function () {
+      const { nft, CAMPAIGN_START } = await loadFixture(deployNFTFixture);
+      expect(await nft.CAMPAIGN_START()).to.equal(CAMPAIGN_START);
+    });
+
+    it("Should set the correct campaign end timestamp", async function () {
+      const { nft, CAMPAIGN_END } = await loadFixture(deployNFTFixture);
+      expect(await nft.CAMPAIGN_END()).to.equal(CAMPAIGN_END);
+    });
+
+    it("Should start with zero total supply", async function () {
+      const { nft } = await loadFixture(deployNFTFixture);
+      expect(await nft.totalSupply()).to.equal(0);
+    });
+
+    it("Should revert on zero address signer", async function () {
+      const JuicerNFT = await ethers.getContractFactory("JuicerNFT");
+      const currentTime = await time.latest();
+      await expect(
+        JuicerNFT.deploy(
+          ethers.ZeroAddress,
+          METADATA_URI,
+          currentTime + 3600,
+          currentTime + 7 * 24 * 3600
+        )
+      ).to.be.revertedWith("Invalid signer address");
+    });
+  });
+
+  describe("Claim Functionality", function () {
+    it("Should allow valid claim with correct signature", async function () {
+      const { nft, signer, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+
+      await expect(nft.connect(user1).claim(signature))
+        .to.emit(nft, "NFTClaimed")
+        .withArgs(user1.address, 1);
+
+      expect(await nft.hasClaimed(user1.address)).to.be.true;
+      expect(await nft.totalSupply()).to.equal(1);
+      expect(await nft.ownerOf(1)).to.equal(user1.address);
+    });
+
+    it("Should mint token ID starting at 1", async function () {
+      const { nft, signer, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(signature);
+
+      expect(await nft.ownerOf(1)).to.equal(user1.address);
+      expect(await nft.totalSupply()).to.equal(1);
+    });
+
+    it("Should allow multiple users to claim", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const sig1 = await generateSignature(await nft.getAddress(), user1.address, signer);
+      const sig2 = await generateSignature(await nft.getAddress(), user2.address, signer);
+
+      await nft.connect(user1).claim(sig1);
+      await nft.connect(user2).claim(sig2);
+
+      expect(await nft.totalSupply()).to.equal(2);
+      expect(await nft.ownerOf(1)).to.equal(user1.address);
+      expect(await nft.ownerOf(2)).to.equal(user2.address);
+    });
+
+    it("Should revert on double claim attempt", async function () {
+      const { nft, signer, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+
+      await nft.connect(user1).claim(signature);
+
+      await expect(nft.connect(user1).claim(signature))
+        .to.be.revertedWithCustomError(nft, "AlreadyClaimed");
+    });
+
+    it("Should revert with invalid signature", async function () {
+      const { nft, user1, attacker } = await loadFixture(deployNFTDuringCampaignFixture);
+      const wrongSignature = await generateSignature(await nft.getAddress(), user1.address, attacker);
+
+      await expect(nft.connect(user1).claim(wrongSignature))
+        .to.be.revertedWithCustomError(nft, "InvalidSignature");
+    });
+
+    it("Should revert when signature is for different address", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+
+      await expect(nft.connect(user2).claim(signature))
+        .to.be.revertedWithCustomError(nft, "InvalidSignature");
+    });
+
+    it("Should revert with malformed signature", async function () {
+      const { nft, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const invalidSignature = "0x1234";
+
+      await expect(nft.connect(user1).claim(invalidSignature))
+        .to.be.reverted;
+    });
+  });
+
+  describe("Token URI (Static Metadata)", function () {
+    it("Should return static metadata URI for token 1", async function () {
+      const { nft, signer, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const sig1 = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(sig1);
+
+      expect(await nft.tokenURI(1)).to.equal(METADATA_URI);
+    });
+
+    it("Should return static metadata URI for token 2", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const sig1 = await generateSignature(await nft.getAddress(), user1.address, signer);
+      const sig2 = await generateSignature(await nft.getAddress(), user2.address, signer);
+      await nft.connect(user1).claim(sig1);
+      await nft.connect(user2).claim(sig2);
+
+      expect(await nft.tokenURI(2)).to.equal(METADATA_URI);
+    });
+
+    it("Should return same URI for all tokens (not appending token ID)", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const sig1 = await generateSignature(await nft.getAddress(), user1.address, signer);
+      const sig2 = await generateSignature(await nft.getAddress(), user2.address, signer);
+      await nft.connect(user1).claim(sig1);
+      await nft.connect(user2).claim(sig2);
+
+      const uri1 = await nft.tokenURI(1);
+      const uri2 = await nft.tokenURI(2);
+
+      expect(uri1).to.equal(uri2);
+      expect(uri1).to.equal(METADATA_URI);
+      expect(uri1).to.not.include("/1");
+      expect(uri2).to.not.include("/2");
+    });
+
+    it("Should revert for non-existent token", async function () {
+      const { nft } = await loadFixture(deployNFTDuringCampaignFixture);
+      await expect(nft.tokenURI(999))
+        .to.be.revertedWithCustomError(nft, "ERC721NonexistentToken");
+    });
+
+    it("Should revert for token ID 0 (tokens start at 1)", async function () {
+      const { nft } = await loadFixture(deployNFTDuringCampaignFixture);
+      await expect(nft.tokenURI(0))
+        .to.be.revertedWithCustomError(nft, "ERC721NonexistentToken");
+    });
+  });
+
+  describe("Total Supply", function () {
+    it("Should start at 0", async function () {
+      const { nft } = await loadFixture(deployNFTDuringCampaignFixture);
+      expect(await nft.totalSupply()).to.equal(0);
+    });
+
+    it("Should increment with each claim", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const sig1 = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(sig1);
+      expect(await nft.totalSupply()).to.equal(1);
+
+      const sig2 = await generateSignature(await nft.getAddress(), user2.address, signer);
+      await nft.connect(user2).claim(sig2);
+      expect(await nft.totalSupply()).to.equal(2);
+    });
+
+    it("Should not increment on failed claims", async function () {
+      const { nft, signer, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(signature);
+      expect(await nft.totalSupply()).to.equal(1);
+
+      // Try to claim again (should fail)
+      await expect(nft.connect(user1).claim(signature))
+        .to.be.revertedWithCustomError(nft, "AlreadyClaimed");
+
+      // Total supply should not change
+      expect(await nft.totalSupply()).to.equal(1);
+    });
+  });
+
+  describe("HasClaimed Mapping", function () {
+    it("Should start as false for all addresses", async function () {
+      const { nft, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      expect(await nft.hasClaimed(user1.address)).to.be.false;
+      expect(await nft.hasClaimed(user2.address)).to.be.false;
+    });
+
+    it("Should be true after successful claim", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(signature);
+
+      expect(await nft.hasClaimed(user1.address)).to.be.true;
+      expect(await nft.hasClaimed(user2.address)).to.be.false;
+    });
+
+    it("Should remain false for other users", async function () {
+      const { nft, signer, user1, user2, attacker } = await loadFixture(deployNFTDuringCampaignFixture);
+      const sig1 = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(sig1);
+
+      expect(await nft.hasClaimed(user1.address)).to.be.true;
+      expect(await nft.hasClaimed(user2.address)).to.be.false;
+      expect(await nft.hasClaimed(attacker.address)).to.be.false;
+    });
+  });
+
+  describe("Event Emission", function () {
+    it("Should emit NFTClaimed event with correct parameters", async function () {
+      const { nft, signer, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+
+      await expect(nft.connect(user1).claim(signature))
+        .to.emit(nft, "NFTClaimed")
+        .withArgs(user1.address, 1);
+    });
+
+    it("Should emit events with incrementing token IDs", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const sig1 = await generateSignature(await nft.getAddress(), user1.address, signer);
+      const sig2 = await generateSignature(await nft.getAddress(), user2.address, signer);
+
+      await expect(nft.connect(user1).claim(sig1))
+        .to.emit(nft, "NFTClaimed")
+        .withArgs(user1.address, 1);
+
+      await expect(nft.connect(user2).claim(sig2))
+        .to.emit(nft, "NFTClaimed")
+        .withArgs(user2.address, 2);
+    });
+  });
+
+  describe("ERC721 Compliance", function () {
+    it("Should support ERC721 interface", async function () {
+      const { nft, signer, user1 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(signature);
+
+      // ERC721 interface ID: 0x80ac58cd
+      expect(await nft.supportsInterface("0x80ac58cd")).to.be.true;
+    });
+
+    it("Should allow token transfers", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(signature);
+
+      await nft.connect(user1).transferFrom(user1.address, user2.address, 1);
+      expect(await nft.ownerOf(1)).to.equal(user2.address);
+    });
+
+    it("Should allow approved transfers", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(signature);
+
+      await nft.connect(user1).approve(user2.address, 1);
+      await nft.connect(user2).transferFrom(user1.address, user2.address, 1);
+      expect(await nft.ownerOf(1)).to.equal(user2.address);
+    });
+  });
+
+  describe("Security Tests", function () {
+    it("Should prevent signature replay after transfer", async function () {
+      const { nft, signer, user1, user2 } = await loadFixture(deployNFTDuringCampaignFixture);
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await nft.connect(user1).claim(signature);
+
+      await nft.connect(user1).transferFrom(user1.address, user2.address, 1);
+
+      await expect(nft.connect(user1).claim(signature))
+        .to.be.revertedWithCustomError(nft, "AlreadyClaimed");
+    });
+
+    it("Should maintain immutable signer address", async function () {
+      const { nft, signer } = await loadFixture(deployNFTDuringCampaignFixture);
+      expect(await nft.signer()).to.equal(signer.address);
+    });
+
+    it("Should maintain immutable campaign start", async function () {
+      const { nft, CAMPAIGN_START } = await loadFixture(deployNFTDuringCampaignFixture);
+      expect(await nft.CAMPAIGN_START()).to.equal(CAMPAIGN_START);
+    });
+
+    it("Should maintain immutable campaign end", async function () {
+      const { nft, CAMPAIGN_END } = await loadFixture(deployNFTDuringCampaignFixture);
+      expect(await nft.CAMPAIGN_END()).to.equal(CAMPAIGN_END);
+    });
+  });
+
+  describe("Campaign Timeframe", function () {
+    it("Should revert claims before campaign start", async function () {
+      const { nft, signer, user1, CAMPAIGN_START } = await loadFixture(deployNFTFixture);
+      await time.increaseTo(CAMPAIGN_START - 10);
+
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await expect(nft.connect(user1).claim(signature))
+        .to.be.revertedWithCustomError(nft, "CampaignNotStarted");
+    });
+
+    it("Should allow claims at exact campaign start", async function () {
+      const { nft, signer, user1, CAMPAIGN_START } = await loadFixture(deployNFTFixture);
+      await time.increaseTo(CAMPAIGN_START);
+
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await expect(nft.connect(user1).claim(signature))
+        .to.emit(nft, "NFTClaimed")
+        .withArgs(user1.address, 1);
+    });
+
+    it("Should allow claims during campaign window", async function () {
+      const { nft, signer, user1, CAMPAIGN_START, CAMPAIGN_END } = await loadFixture(deployNFTFixture);
+      const midCampaign = CAMPAIGN_START + Math.floor((CAMPAIGN_END - CAMPAIGN_START) / 2);
+      await time.increaseTo(midCampaign);
+
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await expect(nft.connect(user1).claim(signature))
+        .to.emit(nft, "NFTClaimed");
+    });
+
+    it("Should allow claims before deadline", async function () {
+      const { nft, signer, user1, CAMPAIGN_END } = await loadFixture(deployNFTFixture);
+      await time.increaseTo(CAMPAIGN_END - 1000);
+
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await expect(nft.connect(user1).claim(signature))
+        .to.emit(nft, "NFTClaimed");
+    });
+
+    it("Should allow claims at exact deadline", async function () {
+      const { nft, signer, user1, CAMPAIGN_END } = await loadFixture(deployNFTFixture);
+      // Use setNextBlockTimestamp to ensure exact timing
+      await time.setNextBlockTimestamp(CAMPAIGN_END);
+
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await expect(nft.connect(user1).claim(signature))
+        .to.emit(nft, "NFTClaimed");
+    });
+
+    it("Should revert claims after deadline", async function () {
+      const { nft, signer, user1, CAMPAIGN_END } = await loadFixture(deployNFTFixture);
+      await time.increaseTo(CAMPAIGN_END + 10);
+
+      const signature = await generateSignature(await nft.getAddress(), user1.address, signer);
+      await expect(nft.connect(user1).claim(signature))
+        .to.be.revertedWithCustomError(nft, "CampaignEnded");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`JuicerNFT.sol\`, the campaign NFT for the post-launch Juicer loyalty drop. Structurally identical to \`FirstSqueezerNFT\` (same backend-signature claim, one-mint-per-address, immutable campaign window, static IPFS metadata) — only the eligibility rules enforced server-side by the signer differ.

## Eligibility (off-chain, signer enforces)

- \`>= 10\` confirmed JuiceSwap swaps from the claimer address
- \`>= \$5\` active deposit in JUSD savings
- \`>= \$5\` active lending position in JUSD

The contract itself does not see any of these — it trusts the backend signer to only sign messages for wallets that satisfy all three.

## Files

- \`contracts/nft/JuicerNFT.sol\` — ERC721 name \`Juicer\` / symbol \`JUICER\`.
- \`test/JuicerNFT.test.ts\` — mirrored from \`FirstSqueezerNFT.test.ts\`, full coverage of campaign window guards, signature recovery, replay protection.

## Companion PRs

- \`JuiceSwapxyz/api\` — \`/v1/campaigns/juicer/*\` endpoints (signer + eligibility checks).
- \`JuiceSwapxyz/bapp\` — \`/juicer\` page + navbar tab.

## Deploy

After merge, deploy via \`scripts/createNFT.ts\` (or a similar script — happy to add a dedicated deploy script if helpful) with:

\`\`\`bash
SIGNER_ADDRESS=0x...   # backend hot wallet
BASE_URI=ipfs://Qm...  # finalised metadata pin
CAMPAIGN_START=...     # unix
CAMPAIGN_END=...       # unix
\`\`\`

Address goes back into \`api\` (signer) and \`bapp\` (claim button).