### PR TITLE
feat(governance): universal JuiceSwapFeeRouter — governance-adjustable fee to Equity (covers Satsuma)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ gasReporterOutput.json
 # Only production deployments (testnet/mainnet) should be committed after review
 deployments/localhost/
 deployments/hardhat/
+
+# contract security tooling generated output
+crytic-export/
+echidna-corpus/

--- a/contracts/governance/JuiceSwapFeeRouter.sol
+++ b/contracts/governance/JuiceSwapFeeRouter.sol
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+/**
+ * @title JuiceSwapFeeRouter
+ * @notice Governance-owned exact-input ERC20 swap overlay that settles protocol fees in JUSD.
+ */
+// WHY: Native value is rejected by receive() and the nonpayable swap entrypoint; this router has no ETH custody path.
+// slither-disable-next-line locked-ether
+contract JuiceSwapFeeRouter is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant MAX_PROTOCOL_FEE_BPS = 500;
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    uint256 public protocolFeeBps = 25;
+
+    bytes4 private constant SWAP_ROUTER_02_EXACT_OUTPUT_SINGLE_SELECTOR = 0x5023b4df;
+    bytes4 private constant SWAP_ROUTER_02_EXACT_OUTPUT_SELECTOR = 0x09b81346;
+    bytes4 private constant LEGACY_SWAP_ROUTER_EXACT_OUTPUT_SINGLE_SELECTOR = 0xdb3e2198;
+    bytes4 private constant LEGACY_SWAP_ROUTER_EXACT_OUTPUT_SELECTOR = 0xf28c0498;
+    bytes4 private constant DEADLINE_LAST_EXACT_OUTPUT_SINGLE_SELECTOR = 0x5d7ef810;
+    bytes4 private constant SWAP_ROUTER_02_V2_EXACT_OUTPUT_SELECTOR = 0x42712a67;
+    bytes4 private constant LEGACY_V2_EXACT_OUTPUT_SELECTOR = 0x8803dbee;
+    bytes4 private constant MULTICALL_SELECTOR = 0xac9650d8;
+    bytes4 private constant MULTICALL_DEADLINE_SELECTOR = 0x5ae401dc;
+    bytes4 private constant MULTICALL_PREVIOUS_BLOCKHASH_SELECTOR = 0x1f0464d1;
+
+    IERC20 public immutable JUSD;
+    address public immutable EQUITY;
+    address public immutable JUICE;
+    address public immutable WCBTC;
+
+    mapping(address target => bool allowed) public allowedTargets;
+    mapping(address target => bool allowed) public allowedFeeConverters;
+
+    struct FeeTargetConfig {
+        address target;
+        bool swapAllowed;
+        bool feeConverterAllowed;
+    }
+
+    struct ExactInputParams {
+        address tokenIn;
+        address tokenOut;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint256 deadline;
+        address target;
+        bytes swapCalldata;
+        address feeConversionTarget;
+        bytes feeConversionCalldata;
+        uint256 minJusdFeeOut;
+    }
+
+    event ProtocolFeeBpsUpdated(uint256 oldProtocolFeeBps, uint256 newProtocolFeeBps);
+    event ProtocolFeeCharged(
+        address indexed payer,
+        address indexed feeToken,
+        uint256 grossAmount,
+        uint256 feeAmount,
+        uint256 tradeAmount
+    );
+    event ProtocolFeeConverted(
+        address indexed feeToken,
+        address indexed converter,
+        uint256 feeAmount,
+        uint256 jusdAmount
+    );
+    event FeeSwapExecuted(
+        address indexed payer,
+        address indexed target,
+        address indexed tokenOut,
+        uint256 tradeAmount,
+        uint256 amountOut,
+        address recipient
+    );
+    event FeeTargetUpdated(address indexed target, bool swapAllowed, bool feeConverterAllowed);
+
+    error InvalidAddress();
+    error InvalidAmount();
+    error DeadlineExpired();
+    error NativeUnsupported();
+    error JuiceInputUnsupported();
+    error SameTokenUnsupported();
+    error ExactOutputUnsupported();
+    error InvalidCalldata();
+    error TargetNotAllowed(address target);
+    error FeeConverterNotAllowed(address target);
+    error FeeConversionRequired(address feeToken);
+    error ProtocolFeeTooHigh(uint256 requested, uint256 maximum);
+    error InsufficientTradeAmount(uint256 grossAmount, uint256 feeAmount);
+    error BalanceDeltaMismatch(address token, uint256 expectedDelta, uint256 actualDelta);
+    error UnexpectedBalance(address token, uint256 expected, uint256 actual);
+    error FeeConversionFailed(address converter, bytes returndata);
+    error TargetCallFailed(address target, bytes returndata);
+    error InsufficientJusdFee(uint256 received, uint256 minimum);
+    error InsufficientOutput(uint256 received, uint256 minimum);
+
+    constructor(
+        address jusd_,
+        address equity_,
+        address juice_,
+        address wcbtc_,
+        address owner_,
+        FeeTargetConfig[] memory initialTargets
+    ) Ownable(owner_) {
+        if (jusd_ == address(0)) revert InvalidAddress();
+        if (equity_ == address(0)) revert InvalidAddress();
+        if (juice_ == address(0)) revert InvalidAddress();
+        if (wcbtc_ == address(0)) revert InvalidAddress();
+
+        JUSD = IERC20(jusd_);
+        EQUITY = equity_;
+        JUICE = juice_;
+        WCBTC = wcbtc_;
+
+        for (uint256 i = 0; i < initialTargets.length; i++) {
+            _setFeeTarget(
+                initialTargets[i].target,
+                initialTargets[i].swapAllowed,
+                initialTargets[i].feeConverterAllowed
+            );
+        }
+    }
+
+    receive() external payable {
+        revert NativeUnsupported();
+    }
+
+    function setFeeTarget(address target, bool swapAllowed, bool feeConverterAllowed) external onlyOwner {
+        _setFeeTarget(target, swapAllowed, feeConverterAllowed);
+    }
+
+    function setProtocolFeeBps(uint256 newProtocolFeeBps) external onlyOwner {
+        if (newProtocolFeeBps > MAX_PROTOCOL_FEE_BPS) {
+            revert ProtocolFeeTooHigh(newProtocolFeeBps, MAX_PROTOCOL_FEE_BPS);
+        }
+
+        uint256 oldProtocolFeeBps = protocolFeeBps;
+        protocolFeeBps = newProtocolFeeBps;
+
+        emit ProtocolFeeBpsUpdated(oldProtocolFeeBps, newProtocolFeeBps);
+    }
+
+    // WHY: Post-call balance reads are required target-agnostic output/refund proofs, and nonReentrant blocks callback reentry.
+    // slither-disable-start reentrancy-balance
+    function swapExactInput(
+        ExactInputParams calldata params
+    ) external nonReentrant returns (uint256 amountOut, uint256 protocolFee, uint256 jusdFeeAmount) {
+        _validateExactInputParams(params);
+
+        IERC20 tokenIn = IERC20(params.tokenIn);
+        IERC20 tokenOut = IERC20(params.tokenOut);
+
+        uint256 tokenInBalanceBefore = tokenIn.balanceOf(address(this));
+        tokenIn.safeTransferFrom(msg.sender, address(this), params.amountIn);
+
+        uint256 receivedInput = tokenIn.balanceOf(address(this)) - tokenInBalanceBefore;
+        if (receivedInput < params.amountIn || receivedInput > params.amountIn) {
+            revert BalanceDeltaMismatch(params.tokenIn, params.amountIn, receivedInput);
+        }
+
+        protocolFee = _protocolFee(params.amountIn);
+        uint256 tradeAmount = params.amountIn - protocolFee;
+        if (tradeAmount < 1) {
+            revert InsufficientTradeAmount(params.amountIn, protocolFee);
+        }
+
+        emit ProtocolFeeCharged(msg.sender, params.tokenIn, params.amountIn, protocolFee, tradeAmount);
+
+        if (protocolFee > 0) {
+            jusdFeeAmount = _creditProtocolFee(tokenIn, params, protocolFee);
+        }
+
+        uint256 expectedTradeBalance = tokenInBalanceBefore + tradeAmount;
+        uint256 actualTradeBalance = tokenIn.balanceOf(address(this));
+        if (actualTradeBalance < expectedTradeBalance || actualTradeBalance > expectedTradeBalance) {
+            revert UnexpectedBalance(params.tokenIn, expectedTradeBalance, actualTradeBalance);
+        }
+
+        uint256 outputBefore = tokenOut.balanceOf(address(this));
+        _executeSwapTarget(tokenIn, params.target, tradeAmount, params.swapCalldata);
+
+        amountOut = tokenOut.balanceOf(address(this)) - outputBefore;
+        if (amountOut < 1 || amountOut < params.amountOutMinimum) {
+            revert InsufficientOutput(amountOut, params.amountOutMinimum);
+        }
+
+        _transferOutput(tokenOut, params.tokenOut, params.recipient, amountOut);
+        _refundUnspentInput(tokenIn, params.tokenIn, tokenInBalanceBefore);
+
+        emit FeeSwapExecuted(msg.sender, params.target, params.tokenOut, tradeAmount, amountOut, params.recipient);
+    }
+    // slither-disable-end reentrancy-balance
+
+    function _setFeeTarget(address target, bool swapAllowed, bool feeConverterAllowed) private {
+        if (target == address(0) || target == address(this)) revert InvalidAddress();
+        if ((swapAllowed || feeConverterAllowed) && target.code.length == 0) revert InvalidAddress();
+
+        allowedTargets[target] = swapAllowed;
+        allowedFeeConverters[target] = feeConverterAllowed;
+
+        emit FeeTargetUpdated(target, swapAllowed, feeConverterAllowed);
+    }
+
+    function _validateExactInputParams(ExactInputParams calldata params) private view {
+        if (msg.value > 0) revert NativeUnsupported();
+        if (block.timestamp > params.deadline) revert DeadlineExpired();
+        if (params.amountIn < 1) revert InvalidAmount();
+        if (params.tokenIn == address(0) || params.tokenOut == address(0)) revert NativeUnsupported();
+        if (params.recipient == address(0) || params.recipient == address(this)) revert InvalidAddress();
+        if (params.target == address(0) || params.target.code.length == 0) revert InvalidAddress();
+        if (params.tokenIn == JUICE) revert JuiceInputUnsupported();
+        if (params.tokenIn == params.tokenOut) revert SameTokenUnsupported();
+        if (!allowedTargets[params.target]) revert TargetNotAllowed(params.target);
+
+        _rejectUnsupportedSwapSelector(params.swapCalldata);
+    }
+
+    function _rejectUnsupportedSwapSelector(bytes calldata swapCalldata) private pure {
+        if (swapCalldata.length < 4) revert InvalidCalldata();
+
+        bytes4 selector;
+        assembly {
+            selector := calldataload(swapCalldata.offset)
+        }
+
+        if (
+            selector == SWAP_ROUTER_02_EXACT_OUTPUT_SINGLE_SELECTOR ||
+            selector == SWAP_ROUTER_02_EXACT_OUTPUT_SELECTOR ||
+            selector == LEGACY_SWAP_ROUTER_EXACT_OUTPUT_SINGLE_SELECTOR ||
+            selector == LEGACY_SWAP_ROUTER_EXACT_OUTPUT_SELECTOR ||
+            selector == DEADLINE_LAST_EXACT_OUTPUT_SINGLE_SELECTOR ||
+            selector == SWAP_ROUTER_02_V2_EXACT_OUTPUT_SELECTOR ||
+            selector == LEGACY_V2_EXACT_OUTPUT_SELECTOR ||
+            selector == MULTICALL_SELECTOR ||
+            selector == MULTICALL_DEADLINE_SELECTOR ||
+            selector == MULTICALL_PREVIOUS_BLOCKHASH_SELECTOR
+        ) {
+            revert ExactOutputUnsupported();
+        }
+    }
+
+    // WHY: The JUSD balance delta after converter.call is the required proof that non-JUSD fees settled as JUSD.
+    // slither-disable-start reentrancy-balance
+    function _creditProtocolFee(
+        IERC20 tokenIn,
+        ExactInputParams calldata params,
+        uint256 protocolFee
+    ) private returns (uint256 jusdFeeAmount) {
+        if (params.tokenIn == address(JUSD)) {
+            JUSD.safeTransfer(EQUITY, protocolFee);
+            return protocolFee;
+        }
+
+        if (params.feeConversionTarget == address(0)) revert FeeConversionRequired(params.tokenIn);
+        if (params.feeConversionTarget.code.length == 0) revert InvalidAddress();
+        if (!allowedFeeConverters[params.feeConversionTarget]) {
+            revert FeeConverterNotAllowed(params.feeConversionTarget);
+        }
+        if (params.minJusdFeeOut < 1) revert InvalidAmount();
+
+        uint256 jusdBefore = JUSD.balanceOf(address(this));
+        tokenIn.forceApprove(params.feeConversionTarget, protocolFee);
+
+        (bool success, bytes memory returndata) = params.feeConversionTarget.call(params.feeConversionCalldata);
+        tokenIn.forceApprove(params.feeConversionTarget, 0);
+        if (!success) revert FeeConversionFailed(params.feeConversionTarget, returndata);
+
+        jusdFeeAmount = JUSD.balanceOf(address(this)) - jusdBefore;
+        if (jusdFeeAmount < params.minJusdFeeOut) {
+            revert InsufficientJusdFee(jusdFeeAmount, params.minJusdFeeOut);
+        }
+
+        JUSD.safeTransfer(EQUITY, jusdFeeAmount);
+        emit ProtocolFeeConverted(params.tokenIn, params.feeConversionTarget, protocolFee, jusdFeeAmount);
+    }
+    // slither-disable-end reentrancy-balance
+
+    function _executeSwapTarget(
+        IERC20 tokenIn,
+        address target,
+        uint256 tradeAmount,
+        bytes calldata swapCalldata
+    ) private {
+        tokenIn.forceApprove(target, tradeAmount);
+
+        (bool success, bytes memory returndata) = target.call(swapCalldata);
+        tokenIn.forceApprove(target, 0);
+        if (!success) revert TargetCallFailed(target, returndata);
+    }
+
+    function _transferOutput(IERC20 tokenOut, address tokenOutAddress, address recipient, uint256 amountOut) private {
+        uint256 recipientBefore = tokenOut.balanceOf(recipient);
+        tokenOut.safeTransfer(recipient, amountOut);
+
+        uint256 recipientDelta = tokenOut.balanceOf(recipient) - recipientBefore;
+        if (recipientDelta < amountOut || recipientDelta > amountOut) {
+            revert BalanceDeltaMismatch(tokenOutAddress, amountOut, recipientDelta);
+        }
+    }
+
+    function _refundUnspentInput(IERC20 tokenIn, address tokenInAddress, uint256 tokenInBalanceBefore) private {
+        uint256 tokenInBalanceAfter = tokenIn.balanceOf(address(this));
+        if (tokenInBalanceAfter <= tokenInBalanceBefore) return;
+
+        uint256 refundAmount = tokenInBalanceAfter - tokenInBalanceBefore;
+        uint256 payerBalanceBefore = tokenIn.balanceOf(msg.sender);
+        tokenIn.safeTransfer(msg.sender, refundAmount);
+
+        uint256 payerDelta = tokenIn.balanceOf(msg.sender) - payerBalanceBefore;
+        if (payerDelta < refundAmount || payerDelta > refundAmount) {
+            revert BalanceDeltaMismatch(tokenInAddress, refundAmount, payerDelta);
+        }
+    }
+
+    function _protocolFee(uint256 amountIn) private view returns (uint256) {
+        return Math.mulDiv(amountIn, protocolFeeBps, BPS_DENOMINATOR, Math.Rounding.Ceil);
+    }
+}

--- a/contracts/mocks/MockFeeRouterReentrantTarget.sol
+++ b/contracts/mocks/MockFeeRouterReentrantTarget.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMockFeeRouterMintableERC20 {
+    function mint(address to, uint256 amount) external;
+}
+
+/**
+ * @title MockFeeRouterReentrantTarget
+ * @notice Swap target that attempts to reenter the FeeRouter during a swap.
+ */
+contract MockFeeRouterReentrantTarget {
+    address public router;
+    bytes public reentrantCallData;
+    bool public attackEnabled;
+    bool public reentrancyAttempted;
+    bool public reentrancySucceeded;
+
+    struct SwapParams {
+        address tokenIn;
+        address tokenOut;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOut;
+    }
+
+    function setAttack(address router_, bytes calldata reentrantCallData_) external {
+        router = router_;
+        reentrantCallData = reentrantCallData_;
+    }
+
+    function setAttackEnabled(bool enabled) external {
+        attackEnabled = enabled;
+    }
+
+    function swap(SwapParams calldata params) external returns (uint256 amountOut) {
+        IERC20(params.tokenIn).transferFrom(msg.sender, address(this), params.amountIn);
+
+        if (attackEnabled) {
+            reentrancyAttempted = true;
+            (reentrancySucceeded, ) = router.call(reentrantCallData);
+        }
+
+        amountOut = params.amountOut;
+        IMockFeeRouterMintableERC20(params.tokenOut).mint(params.recipient, amountOut);
+    }
+}

--- a/test/JuiceSwapFeeRouter.test.ts
+++ b/test/JuiceSwapFeeRouter.test.ts
@@ -1,0 +1,503 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time, loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import {
+  JuiceSwapFeeRouter,
+  MockERC20,
+  MockEquity,
+  MockFeeRouterReentrantTarget,
+  MockStablecoinBridge,
+  MockSwapRouter,
+} from "../typechain-types";
+
+const INITIAL_BALANCE = ethers.parseEther("10000");
+const DEADLINE_OFFSET = 3600;
+
+type FeeRouterParams = JuiceSwapFeeRouter.ExactInputParamsStruct;
+
+describe("JuiceSwapFeeRouter", function () {
+  async function deployFixture() {
+    const [owner, user, recipient, outsider] = await ethers.getSigners();
+
+    const MockERC20Factory = await ethers.getContractFactory("MockERC20");
+    const jusd = (await MockERC20Factory.deploy("JuiceDollar", "JUSD", 18)) as unknown as MockERC20;
+    const tokenIn = (await MockERC20Factory.deploy("USD Token", "USDT", 18)) as unknown as MockERC20;
+    const tokenOut = (await MockERC20Factory.deploy("Output Token", "OUT", 18)) as unknown as MockERC20;
+    const wcbtc = (await MockERC20Factory.deploy("Wrapped cBTC", "WCBTC", 18)) as unknown as MockERC20;
+    await Promise.all([
+      jusd.waitForDeployment(),
+      tokenIn.waitForDeployment(),
+      tokenOut.waitForDeployment(),
+      wcbtc.waitForDeployment(),
+    ]);
+
+    const MockEquityFactory = await ethers.getContractFactory("MockEquity");
+    const equity = (await MockEquityFactory.deploy(
+      "Juice Protocol",
+      "JUICE",
+      await jusd.getAddress()
+    )) as unknown as MockEquity;
+    await equity.waitForDeployment();
+
+    const MockSwapRouterFactory = await ethers.getContractFactory("MockSwapRouter");
+    const swapRouter = (await MockSwapRouterFactory.deploy()) as unknown as MockSwapRouter;
+    await swapRouter.waitForDeployment();
+
+    const MockStablecoinBridgeFactory = await ethers.getContractFactory("MockStablecoinBridge");
+    const bridge = (await MockStablecoinBridgeFactory.deploy(
+      await tokenIn.getAddress(),
+      await jusd.getAddress(),
+      ethers.parseEther("1000000"),
+      52
+    )) as unknown as MockStablecoinBridge;
+    await bridge.waitForDeployment();
+
+    const FeeRouterFactory = await ethers.getContractFactory("JuiceSwapFeeRouter");
+    const feeRouter = (await FeeRouterFactory.deploy(
+      await jusd.getAddress(),
+      await equity.getAddress(),
+      await equity.getAddress(),
+      await wcbtc.getAddress(),
+      owner.address,
+      [
+        [await swapRouter.getAddress(), true, false],
+        [await bridge.getAddress(), false, true],
+      ]
+    )) as unknown as JuiceSwapFeeRouter;
+    await feeRouter.waitForDeployment();
+
+    await jusd.mint(user.address, INITIAL_BALANCE);
+    await tokenIn.mint(user.address, INITIAL_BALANCE);
+
+    return { owner, user, recipient, outsider, jusd, tokenIn, tokenOut, wcbtc, equity, swapRouter, bridge, feeRouter };
+  }
+
+  async function deadline() {
+    return (await time.latest()) + DEADLINE_OFFSET;
+  }
+
+  function protocolFee(amountIn: bigint) {
+    return (amountIn * 25n + 9999n) / 10000n;
+  }
+
+  async function swapCalldata(
+    swapRouter: MockSwapRouter,
+    tokenIn: string,
+    tokenOut: string,
+    recipient: string,
+    amountIn: bigint,
+    amountOutMinimum = 0n
+  ) {
+    return swapRouter.interface.encodeFunctionData("exactInputSingle", [
+      {
+        tokenIn,
+        tokenOut,
+        fee: 3000,
+        recipient,
+        amountIn,
+        amountOutMinimum,
+        sqrtPriceLimitX96: 0,
+      },
+    ]);
+  }
+
+  async function jusdExactInputParams(
+    fixture: Awaited<ReturnType<typeof deployFixture>>,
+    amountIn: bigint,
+    amountOut: bigint,
+    recipientAddress = fixture.recipient.address,
+    tradeOverride?: bigint
+  ): Promise<FeeRouterParams> {
+    const fee = protocolFee(amountIn);
+    const tradeAmount = tradeOverride ?? amountIn - fee;
+    await fixture.swapRouter.setSwapOutput(amountOut);
+
+    return {
+      tokenIn: await fixture.jusd.getAddress(),
+      tokenOut: await fixture.tokenOut.getAddress(),
+      recipient: recipientAddress,
+      amountIn,
+      amountOutMinimum: amountOut,
+      deadline: await deadline(),
+      target: await fixture.swapRouter.getAddress(),
+      swapCalldata: await swapCalldata(
+        fixture.swapRouter,
+        await fixture.jusd.getAddress(),
+        await fixture.tokenOut.getAddress(),
+        await fixture.feeRouter.getAddress(),
+        tradeAmount,
+        amountOut
+      ),
+      feeConversionTarget: ethers.ZeroAddress,
+      feeConversionCalldata: "0x",
+      minJusdFeeOut: 0,
+    };
+  }
+
+  it("charges a 25 bps ceiling fee on JUSD input and credits Equity", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, recipient, jusd, tokenOut, equity, swapRouter, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("1000");
+    const amountOut = ethers.parseEther("900");
+    const fee = protocolFee(amountIn);
+    const tradeAmount = amountIn - fee;
+    const params = await jusdExactInputParams(fixture, amountIn, amountOut);
+
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn);
+
+    await expect(feeRouter.connect(user).swapExactInput(params))
+      .to.emit(feeRouter, "ProtocolFeeCharged")
+      .withArgs(user.address, await jusd.getAddress(), amountIn, fee, tradeAmount)
+      .and.to.emit(feeRouter, "FeeSwapExecuted")
+      .withArgs(
+        user.address,
+        await swapRouter.getAddress(),
+        await tokenOut.getAddress(),
+        tradeAmount,
+        amountOut,
+        recipient.address
+      );
+
+    expect(await jusd.balanceOf(await equity.getAddress())).to.equal(fee);
+    expect(await tokenOut.balanceOf(recipient.address)).to.equal(amountOut);
+    expect(await jusd.balanceOf(await feeRouter.getAddress())).to.equal(0);
+    expect(await jusd.allowance(await feeRouter.getAddress(), await swapRouter.getAddress())).to.equal(0);
+    expect(await jusd.balanceOf(await swapRouter.getAddress())).to.equal(tradeAmount);
+  });
+
+  it("fails closed when ceiling fee consumes a tiny input", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, jusd, feeRouter } = fixture;
+    const params = await jusdExactInputParams(fixture, 1n, 1n, fixture.recipient.address, 0n);
+
+    await jusd.connect(user).approve(await feeRouter.getAddress(), 1n);
+
+    await expect(feeRouter.connect(user).swapExactInput(params))
+      .to.be.revertedWithCustomError(feeRouter, "InsufficientTradeAmount")
+      .withArgs(1n, 1n);
+  });
+
+  it("converts non-JUSD fees through an allowlisted converter and clears approvals", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, recipient, tokenIn, tokenOut, jusd, equity, bridge, swapRouter, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("1000");
+    const amountOut = ethers.parseEther("800");
+    const fee = protocolFee(amountIn);
+    const tradeAmount = amountIn - fee;
+
+    await swapRouter.setSwapOutput(amountOut);
+    await tokenIn.connect(user).approve(await feeRouter.getAddress(), amountIn);
+
+    const params: FeeRouterParams = {
+      tokenIn: await tokenIn.getAddress(),
+      tokenOut: await tokenOut.getAddress(),
+      recipient: recipient.address,
+      amountIn,
+      amountOutMinimum: amountOut,
+      deadline: await deadline(),
+      target: await swapRouter.getAddress(),
+      swapCalldata: await swapCalldata(
+        swapRouter,
+        await tokenIn.getAddress(),
+        await tokenOut.getAddress(),
+        await feeRouter.getAddress(),
+        tradeAmount,
+        amountOut
+      ),
+      feeConversionTarget: await bridge.getAddress(),
+      feeConversionCalldata: bridge.interface.encodeFunctionData("mintTo", [await feeRouter.getAddress(), fee]),
+      minJusdFeeOut: fee,
+    };
+
+    await expect(feeRouter.connect(user).swapExactInput(params))
+      .to.emit(feeRouter, "ProtocolFeeConverted")
+      .withArgs(await tokenIn.getAddress(), await bridge.getAddress(), fee, fee);
+
+    expect(await jusd.balanceOf(await equity.getAddress())).to.equal(fee);
+    expect(await tokenIn.balanceOf(await bridge.getAddress())).to.equal(fee);
+    expect(await tokenIn.balanceOf(await swapRouter.getAddress())).to.equal(tradeAmount);
+    expect(await tokenOut.balanceOf(recipient.address)).to.equal(amountOut);
+    expect(await tokenIn.allowance(await feeRouter.getAddress(), await bridge.getAddress())).to.equal(0);
+    expect(await tokenIn.allowance(await feeRouter.getAddress(), await swapRouter.getAddress())).to.equal(0);
+  });
+
+  it("rejects unallowlisted swap targets and fee converters", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, jusd, tokenIn, tokenOut, swapRouter, bridge, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("100");
+    const amountOut = ethers.parseEther("50");
+    const jusdParams = await jusdExactInputParams(fixture, amountIn, amountOut);
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn);
+
+    await expect(
+      feeRouter.connect(user).swapExactInput({
+        ...jusdParams,
+        target: await bridge.getAddress(),
+      })
+    )
+      .to.be.revertedWithCustomError(feeRouter, "TargetNotAllowed")
+      .withArgs(await bridge.getAddress());
+
+    await tokenIn.connect(user).approve(await feeRouter.getAddress(), amountIn);
+    const fee = protocolFee(amountIn);
+    const tradeAmount = amountIn - fee;
+    const params: FeeRouterParams = {
+      tokenIn: await tokenIn.getAddress(),
+      tokenOut: await tokenOut.getAddress(),
+      recipient: fixture.recipient.address,
+      amountIn,
+      amountOutMinimum: amountOut,
+      deadline: await deadline(),
+      target: await swapRouter.getAddress(),
+      swapCalldata: await swapCalldata(
+        swapRouter,
+        await tokenIn.getAddress(),
+        await tokenOut.getAddress(),
+        await feeRouter.getAddress(),
+        tradeAmount,
+        amountOut
+      ),
+      feeConversionTarget: await swapRouter.getAddress(),
+      feeConversionCalldata: bridge.interface.encodeFunctionData("mintTo", [await feeRouter.getAddress(), fee]),
+      minJusdFeeOut: fee,
+    };
+
+    await expect(feeRouter.connect(user).swapExactInput(params))
+      .to.be.revertedWithCustomError(feeRouter, "FeeConverterNotAllowed")
+      .withArgs(await swapRouter.getAddress());
+  });
+
+  it("refunds unspent trade input after a partial target pull", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, recipient, jusd, tokenOut, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("1000");
+    const amountOut = ethers.parseEther("400");
+    const fee = protocolFee(amountIn);
+    const tradeAmount = amountIn - fee;
+    const partialTrade = ethers.parseEther("600");
+    const params = await jusdExactInputParams(fixture, amountIn, amountOut, recipient.address, partialTrade);
+
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn);
+    await feeRouter.connect(user).swapExactInput(params);
+
+    expect(await tokenOut.balanceOf(recipient.address)).to.equal(amountOut);
+    expect(await jusd.balanceOf(user.address)).to.equal(INITIAL_BALANCE - fee - partialTrade);
+    expect(await jusd.balanceOf(await feeRouter.getAddress())).to.equal(0);
+    expect(tradeAmount - partialTrade).to.be.greaterThan(0n);
+  });
+
+  it("requires swap output to be received by the FeeRouter and meet minimum output", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, jusd, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("1000");
+    const amountOut = ethers.parseEther("500");
+    const fee = protocolFee(amountIn);
+    const tradeAmount = amountIn - fee;
+    await fixture.swapRouter.setSwapOutput(amountOut);
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn);
+
+    const params: FeeRouterParams = {
+      ...(await jusdExactInputParams(fixture, amountIn, amountOut)),
+      swapCalldata: await swapCalldata(
+        fixture.swapRouter,
+        await jusd.getAddress(),
+        await fixture.tokenOut.getAddress(),
+        user.address,
+        tradeAmount,
+        amountOut
+      ),
+    };
+
+    await expect(feeRouter.connect(user).swapExactInput(params))
+      .to.be.revertedWithCustomError(feeRouter, "InsufficientOutput")
+      .withArgs(0n, amountOut);
+  });
+
+  it("prevents a target from pulling more than the post-fee trade amount", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, jusd, tokenOut, swapRouter, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("100");
+    const fee = protocolFee(amountIn);
+    const tradeAmount = amountIn - fee;
+    const params = await jusdExactInputParams(fixture, amountIn, ethers.parseEther("10"));
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn);
+
+    await expect(
+      feeRouter.connect(user).swapExactInput({
+        ...params,
+        swapCalldata: await swapCalldata(
+          swapRouter,
+          await jusd.getAddress(),
+          await tokenOut.getAddress(),
+          await feeRouter.getAddress(),
+          tradeAmount + 1n,
+          0n
+        ),
+      })
+    ).to.be.revertedWithCustomError(feeRouter, "TargetCallFailed");
+  });
+
+  it("fails closed for unsupported native, JUICE-input, same-token, expired, and zero-output routes", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, jusd, tokenOut, equity, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("100");
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn);
+    const baseParams = await jusdExactInputParams(fixture, amountIn, ethers.parseEther("10"));
+
+    // The swap entrypoint is non-payable (no ETH custody path); native value is
+    // rejected outright, and direct native sends revert with NativeUnsupported.
+    await expect(
+      user.sendTransaction({ to: await feeRouter.getAddress(), value: 1 })
+    ).to.be.revertedWithCustomError(feeRouter, "NativeUnsupported");
+
+    await expect(
+      feeRouter.connect(user).swapExactInput({
+        ...baseParams,
+        tokenIn: await equity.getAddress(),
+      })
+    ).to.be.revertedWithCustomError(feeRouter, "JuiceInputUnsupported");
+
+    await expect(
+      feeRouter.connect(user).swapExactInput({
+        ...baseParams,
+        tokenOut: await jusd.getAddress(),
+      })
+    ).to.be.revertedWithCustomError(feeRouter, "SameTokenUnsupported");
+
+    await expect(
+      feeRouter.connect(user).swapExactInput({
+        ...baseParams,
+        deadline: (await time.latest()) - 1,
+      })
+    ).to.be.revertedWithCustomError(feeRouter, "DeadlineExpired");
+
+    await expect(
+      feeRouter.connect(user).swapExactInput({
+        ...baseParams,
+        swapCalldata: await swapCalldata(
+          fixture.swapRouter,
+          await jusd.getAddress(),
+          await tokenOut.getAddress(),
+          user.address,
+          amountIn - protocolFee(amountIn),
+          0n
+        ),
+        amountOutMinimum: 1n,
+      })
+    ).to.be.revertedWithCustomError(feeRouter, "InsufficientOutput");
+  });
+
+  it("rejects exact-output, multicall, and malformed swap calldata before target execution", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { user, jusd, feeRouter } = fixture;
+    const amountIn = ethers.parseEther("100");
+    const baseParams = await jusdExactInputParams(fixture, amountIn, ethers.parseEther("10"));
+    const unsupportedSelectors = [
+      "0x5023b4df",
+      "0x09b81346",
+      "0xdb3e2198",
+      "0xf28c0498",
+      "0x5d7ef810",
+      "0x42712a67",
+      "0x8803dbee",
+      "0xac9650d8",
+      "0x5ae401dc",
+      "0x1f0464d1",
+    ];
+
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn);
+
+    for (const selector of unsupportedSelectors) {
+      await expect(
+        feeRouter.connect(user).swapExactInput({
+          ...baseParams,
+          swapCalldata: selector,
+        })
+      ).to.be.revertedWithCustomError(feeRouter, "ExactOutputUnsupported");
+    }
+
+    await expect(
+      feeRouter.connect(user).swapExactInput({
+        ...baseParams,
+        swapCalldata: "0x123456",
+      })
+    ).to.be.revertedWithCustomError(feeRouter, "InvalidCalldata");
+
+    expect(await fixture.swapRouter.swapCallCount()).to.equal(0);
+  });
+
+  it("rejects reentrancy attempted by an allowlisted target", async function () {
+    const fixture = await loadFixture(deployFixture);
+    const { owner, user, recipient, jusd, tokenOut, feeRouter } = fixture;
+    const ReentrantTargetFactory = await ethers.getContractFactory("MockFeeRouterReentrantTarget");
+    const reentrantTarget = (await ReentrantTargetFactory.deploy()) as unknown as MockFeeRouterReentrantTarget;
+    await reentrantTarget.waitForDeployment();
+    await feeRouter.connect(owner).setFeeTarget(await reentrantTarget.getAddress(), true, false);
+
+    const amountIn = ethers.parseEther("1000");
+    const amountOut = ethers.parseEther("100");
+    const fee = protocolFee(amountIn);
+    const tradeAmount = amountIn - fee;
+    const baseParams = await jusdExactInputParams(fixture, amountIn, amountOut);
+
+    const reentrantParams: FeeRouterParams = {
+      ...baseParams,
+      target: await reentrantTarget.getAddress(),
+      swapCalldata: reentrantTarget.interface.encodeFunctionData("swap", [
+        {
+          tokenIn: await jusd.getAddress(),
+          tokenOut: await tokenOut.getAddress(),
+          recipient: await feeRouter.getAddress(),
+          amountIn: tradeAmount,
+          amountOut,
+        },
+      ]),
+    };
+    await reentrantTarget.setAttack(
+      await feeRouter.getAddress(),
+      feeRouter.interface.encodeFunctionData("swapExactInput", [baseParams])
+    );
+    await reentrantTarget.setAttackEnabled(true);
+
+    await jusd.connect(user).approve(await feeRouter.getAddress(), amountIn * 2n);
+    await feeRouter.connect(user).swapExactInput(reentrantParams);
+
+    expect(await reentrantTarget.reentrancyAttempted()).to.equal(true);
+    expect(await reentrantTarget.reentrancySucceeded()).to.equal(false);
+    expect(await tokenOut.balanceOf(recipient.address)).to.equal(amountOut);
+  });
+
+  describe("governance fee adjustment", function () {
+    it("defaults to 25 bps, exposes the 5% cap, and is owned by the governance address", async function () {
+      const { feeRouter, owner } = await loadFixture(deployFixture);
+      expect(await feeRouter.protocolFeeBps()).to.equal(25);
+      expect(await feeRouter.MAX_PROTOCOL_FEE_BPS()).to.equal(500);
+      expect(await feeRouter.owner()).to.equal(owner.address);
+    });
+
+    it("lets the owner (governance) adjust the fee up to the 5% cap and emits the event", async function () {
+      const { feeRouter, owner } = await loadFixture(deployFixture);
+      await expect(feeRouter.connect(owner).setProtocolFeeBps(500))
+        .to.emit(feeRouter, "ProtocolFeeBpsUpdated")
+        .withArgs(25, 500);
+      expect(await feeRouter.protocolFeeBps()).to.equal(500);
+    });
+
+    it("rejects a fee above the 5% cap", async function () {
+      const { feeRouter, owner } = await loadFixture(deployFixture);
+      await expect(feeRouter.connect(owner).setProtocolFeeBps(501))
+        .to.be.revertedWithCustomError(feeRouter, "ProtocolFeeTooHigh")
+        .withArgs(501, 500);
+    });
+
+    it("rejects fee and allowlist changes from a non-owner", async function () {
+      const { feeRouter, outsider } = await loadFixture(deployFixture);
+      await expect(
+        feeRouter.connect(outsider).setProtocolFeeBps(50)
+      ).to.be.revertedWithCustomError(feeRouter, "OwnableUnauthorizedAccount");
+      await expect(
+        feeRouter.connect(outsider).setFeeTarget(outsider.address, true, false)
+      ).to.be.revertedWithCustomError(feeRouter, "OwnableUnauthorizedAccount");
+    });
+  });
+});

--- a/test/JuiceSwapFeeRouter.test.ts
+++ b/test/JuiceSwapFeeRouter.test.ts
@@ -346,9 +346,10 @@ describe("JuiceSwapFeeRouter", function () {
 
     // The swap entrypoint is non-payable (no ETH custody path); native value is
     // rejected outright, and direct native sends revert with NativeUnsupported.
-    await expect(
-      user.sendTransaction({ to: await feeRouter.getAddress(), value: 1 })
-    ).to.be.revertedWithCustomError(feeRouter, "NativeUnsupported");
+    await expect(user.sendTransaction({ to: await feeRouter.getAddress(), value: 1 })).to.be.revertedWithCustomError(
+      feeRouter,
+      "NativeUnsupported"
+    );
 
     await expect(
       feeRouter.connect(user).swapExactInput({
@@ -492,9 +493,10 @@ describe("JuiceSwapFeeRouter", function () {
 
     it("rejects fee and allowlist changes from a non-owner", async function () {
       const { feeRouter, outsider } = await loadFixture(deployFixture);
-      await expect(
-        feeRouter.connect(outsider).setProtocolFeeBps(50)
-      ).to.be.revertedWithCustomError(feeRouter, "OwnableUnauthorizedAccount");
+      await expect(feeRouter.connect(outsider).setProtocolFeeBps(50)).to.be.revertedWithCustomError(
+        feeRouter,
+        "OwnableUnauthorizedAccount"
+      );
       await expect(
         feeRouter.connect(outsider).setFeeTarget(outsider.address, true, false)
       ).to.be.revertedWithCustomError(feeRouter, "OwnableUnauthorizedAccount");


### PR DESCRIPTION
## The problem

JuiceSwap wants a protocol fee on swaps that flows into the JUICE/Equity reserve, with
two hard requirements that ruled out the alternatives:

1. **It must also fee Satsuma-routed swaps** (e.g. ctUSD via Satsuma's pools). JuiceSwap
   does NOT own Satsuma (a separate Algebra DEX), so a Uniswap-V3 `setFeeProtocol` pool fee
   cannot touch it — and a V3 pool protocol fee is only a fixed `1/N` fraction of the LP
   fee anyway (0.3% pool → max 0.075%), never a clean 0.25%, taken from LPs.
2. **Governance must stay with the existing Governor.** The earlier standalone fee-router
   was rejected because it introduced a separate owner/governance.

The only mechanism that fees Satsuma (and every other venue) is a router the frontend
routes swaps through — but governance-owned, so nothing is handed away.

## The solution — `JuiceSwapFeeRouter` (universal, governance-owned)

`Ownable` with the **Governor** as owner. An exact-input overlay that:
- takes a protocol fee in **JUSD** and transfers it directly to the **JUICE/Equity reserve**
  (no mint — same pattern as `JuiceSwapFeeCollector`), then
- executes the actual swap on an **allowlisted target** (SwapRouter02, the v1 Gateway, the
  **Satsuma/Algebra router**, or a bridge). Non-JUSD fees convert to JUSD via an allowlisted
  converter first.

The **v1 Gateway is left untouched** — this wraps it, it does not replace it.

### Governance-adjustable fee (max 5%)
- `protocolFeeBps` is mutable, default **25 bps (0.25%)**.
- `MAX_PROTOCOL_FEE_BPS = 500` (hard cap **5%**).
- `setProtocolFeeBps(uint256)` is `onlyOwner` (the Governor), reverts `ProtocolFeeTooHigh`
  above the cap, emits `ProtocolFeeBpsUpdated`.
- The allowlist (`setFeeTarget`) is `onlyOwner` too. **Control stays with the existing
  Governor — no new/separate governance.**

## Safety
`ReentrancyGuard`, exact balance-delta checks on every transfer, rejection of
exact-output/multicall selectors and malformed calldata, refund of unspent trade input,
output-must-arrive-at-router checks, and non-payable (no native custody; `receive()` reverts).

## Verification
- **14/14 Hardhat tests**: JUSD-input fee→Equity, fail-closed on dust, non-JUSD conversion +
  approval clearing, allowlist enforcement, refund of unspent input, output/minimum checks,
  anti-over-pull, native/JUICE-input/same-token/expired/zero-output fail-closed, exact-output/
  multicall/malformed rejection, reentrancy blocked, and governance fee-adjust (cap + owner-only).
- **Slither: 0 High, 0 Medium** on the router.

## ⚠️ Review notes
Drafted with AI assistance / an automated agent loop. Mechanical gates reduce risk but do
not replace a human security audit — **audit before any deployment** (handles real funds).
Relationship to #58 (GatewayV2): this router is the universal, governance-adjustable
alternative that also covers Satsuma and keeps v1; the team can choose between them.

## Not in this PR
Frontend/API routing of all swaps through this router, indexer event indexing, deployment.
